### PR TITLE
Match the official Computer Use tool contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Pi registers namespaced tools to avoid collisions with Pi's built-ins. The MCP s
 
 | Pi tool | MCP method | No-permissions | Purpose |
 |---|---|---:|---|
-| `computer_use_list_apps` | `list_apps` | yes | List apps known to official Computer Use |
-| `computer_use_get_app_state` | `get_app_state` | yes | Read accessibility state and imagery for one app |
+| `computer_use_list_apps` | `list_apps` | yes | List running and recently used apps |
+| `computer_use_get_app_state` | `get_app_state` | yes | Read the key-window screenshot and accessibility tree |
 | `computer_use_click` | `click` | yes | Click an element or screenshot coordinates |
 | `computer_use_perform_secondary_action` | `perform_secondary_action` | yes | Invoke a named accessibility action |
 | `computer_use_set_value` | `set_value` | yes | Assign an accessibility value |
@@ -31,7 +31,9 @@ Pi registers namespaced tools to avoid collisions with Pi's built-ins. The MCP s
 | `computer_use_press_key` | `press_key` | yes | Send a key or key combination |
 | `computer_use_type_text` | `type_text` | yes | Type literal text |
 
-Pi—not a nested planner—must call `computer_use_get_app_state`, choose a current element identifier or coordinates, execute one action, and inspect again when needed.
+The MCP façade preserves the official signed helper's tool descriptions, input schemas, and annotations exactly. The Pi façade preserves its descriptions and input schemas; Pi's tool API does not expose MCP annotations. In particular, all ten MCP methods have `destructiveHint: false`; the wrapper does not conflate changing UI state with destructive behavior or add argument restrictions absent from the official schemas.
+
+As the official contract specifies, Pi—not a nested planner—calls `computer_use_get_app_state` once per assistant turn before interacting with an app, then chooses and executes actions itself.
 
 ## Authorization policy: durable no-permissions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Do not open a public issue for a vulnerability that could weaken signing, schema verification, permission-mode dispatch, first-party approval handling, app identity, locking, focus telemetry, cleanup, or audit integrity.
+Do not open a public issue for a vulnerability that could weaken signing, contract verification, no-permissions dispatch, first-party access handling, app identity, locking, focus telemetry, cleanup, or audit integrity.
 
 Use GitHub private vulnerability reporting. Include the affected commit/version, the smallest non-sensitive reproduction, expected versus observed behavior, and whether an official action completed before failure.
 
@@ -20,7 +20,7 @@ This is direct tool dispatch—not model orchestration.
 
 1. Only fixed app-bundled Codex and Computer Use client paths are allowed in production.
 2. Both binaries pass strict code-signature verification and OpenAI Team ID `2DC432GLL2` checks before dispatch.
-3. The helper's exact ten method names and input schemas match the pinned expected inventory before every call.
+3. The helper's exact ten method names and input schemas match the pinned expected inventory before every call; release tests also verify its descriptions and annotations.
 4. `no-permissions` is the only wrapper policy: all ten methods are exposed and no wrapper permission prompt is opened.
 5. There is no config file, environment override, command, tool argument, per-call branch, or alternate safe/full route that an agent can select.
 6. App-server uses `approvalPolicy: "never"`; elicitation capability is disabled and unexpected first-party requests are silently declined, never prompted or self-accepted. Persistent official app access remains authoritative and must be configured outside this wrapper.
@@ -40,7 +40,7 @@ This is direct tool dispatch—not model orchestration.
 
 ### No-permissions
 
-All ten official methods and arbitrary resolvable app targets are available without wrapper permission prompts. The name means “ask no permission,” not “disable tools.” This is broad authorization. It does not imply that actions are reversible or that focus detection can prevent an already dispatched action. App-state reads can expose visible sensitive information to the calling model.
+All ten official methods and arbitrary resolvable app targets are available without wrapper permission prompts. The name means “ask no permission,” not “disable tools.” This is broad authorization. It does not imply that actions are reversible or that focus detection can prevent an already dispatched action.
 
 The mode is compiled as the sole policy. Agent-writable audit state and legacy configuration files cannot change it, and there is no CLI/slash/tool/environment mode selector.
 
@@ -48,9 +48,9 @@ The mode is compiled as the sole policy. Agent-writable audit state and legacy c
 
 Neither Pi nor stdio MCP advertises or renders an approval UI. The bridge starts app-server with `approvalPolicy: "never"`. An unexpected downstream elicitation is counted, silently declined, and never self-accepted. Persistent first-party app access belongs in official ChatGPT Computer Use settings.
 
-## Visible-content warning
+## Visible content
 
-Computer Use is designed to return app state and screenshots. Do not point it at apps containing credentials, payment data, private messages, or customer secrets unless the user explicitly requires that context and accepts model exposure. Audit safety does not make target-app content non-sensitive.
+Computer Use returns the official app-state text and screenshots to the invoking client. The wrapper does not inspect, classify, redact, or use that content to narrow the actions authorized by the user's request, and it never writes the content to its audit.
 
 ## Supported versions
 

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -4,46 +4,58 @@ import { getAgentDir, truncateHead, type ExtensionAPI } from "@earendil-works/pi
 import { Text } from "@earendil-works/pi-tui";
 import { Type, type TSchema } from "typebox";
 import { executeDirectTool, getDirectStatus } from "../../dist/direct-service.js";
-import type { DirectMethod } from "../../dist/tools.js";
+import { OFFICIAL_TOOL_METADATA, type DirectMethod } from "../../dist/tools.js";
 
-const App = Type.String({ minLength: 1, maxLength: 500, description: "App name, full app path, or unambiguous bundle identifier" });
-const Element = Type.String({ minLength: 1, maxLength: 200, description: "Element identifier from computer_use_get_app_state" });
-const Coordinate = Type.Number({ minimum: 0, maximum: 1_000_000 });
+const App = Type.String({ description: "App name, full app path, or unambiguous bundle identifier" });
 
 const ToolParameters: Record<DirectMethod, TSchema> = {
   list_apps: Type.Object({}, { additionalProperties: false }),
   get_app_state: Type.Object({ app: App }, { additionalProperties: false }),
   click: Type.Object({
     app: App,
-    click_count: Type.Optional(Type.Integer({ minimum: 1, maximum: 10 })),
-    element_index: Type.Optional(Element),
-    mouse_button: Type.Optional(StringEnum(["left", "right", "middle"] as const)),
-    x: Type.Optional(Coordinate),
-    y: Type.Optional(Coordinate),
+    click_count: Type.Optional(Type.Integer({ description: "Number of clicks. Defaults to 1" })),
+    element_index: Type.Optional(Type.String({ description: "Element index to click" })),
+    mouse_button: Type.Optional(StringEnum(["left", "right", "middle"] as const, { description: "Mouse button to click. Defaults to left." })),
+    x: Type.Optional(Type.Number({ description: "X coordinate in screenshot pixel coordinates" })),
+    y: Type.Optional(Type.Number({ description: "Y coordinate in screenshot pixel coordinates" })),
   }, { additionalProperties: false }),
-  perform_secondary_action: Type.Object({ app: App, element_index: Element, action: Type.String({ minLength: 1, maxLength: 200 }) }, { additionalProperties: false }),
-  set_value: Type.Object({ app: App, element_index: Element, value: Type.String({ maxLength: 20_000 }) }, { additionalProperties: false }),
-  select_text: Type.Object({
+  perform_secondary_action: Type.Object({
     app: App,
-    element_index: Element,
-    text: Type.String({ minLength: 1, maxLength: 20_000 }),
-    prefix: Type.Optional(Type.String({ maxLength: 2_000 })),
-    selection: Type.Optional(StringEnum(["text", "cursor_before", "cursor_after"] as const)),
-    suffix: Type.Optional(Type.String({ maxLength: 2_000 })),
+    element_index: Type.String({ description: "Element identifier" }),
+    action: Type.String({ description: "Secondary accessibility action name" }),
+  }, { additionalProperties: false }),
+  set_value: Type.Object({
+    app: App,
+    element_index: Type.String({ description: "Element identifier" }),
+    value: Type.String({ description: "Value to assign" }),
+  }, { additionalProperties: false }),
+  select_text: Type.Object({
+    app: Type.String({ description: "App name or bundle identifier" }),
+    element_index: Type.String({ description: "Text element identifier" }),
+    text: Type.String({ description: "Target text as shown in the accessibility tree" }),
+    prefix: Type.Optional(Type.String({ description: "Optional text immediately before the target, used to disambiguate repeated matches" })),
+    selection: Type.Optional(StringEnum(["text", "cursor_before", "cursor_after"] as const, { description: "Whether to select the text or place the cursor before or after it. Defaults to text." })),
+    suffix: Type.Optional(Type.String({ description: "Optional text immediately after the target, used to disambiguate repeated matches" })),
   }, { additionalProperties: false }),
   scroll: Type.Object({
     app: App,
-    element_index: Element,
-    direction: StringEnum(["up", "down", "left", "right"] as const),
-    pages: Type.Optional(Type.Number({ exclusiveMinimum: 0, maximum: 100 })),
+    element_index: Type.String({ description: "Element identifier" }),
+    direction: Type.String({ description: "Scroll direction: up, down, left, or right" }),
+    pages: Type.Optional(Type.Number({ description: "Number of pages to scroll. Fractional values are supported. Defaults to 1" })),
   }, { additionalProperties: false }),
-  drag: Type.Object({ app: App, from_x: Coordinate, from_y: Coordinate, to_x: Coordinate, to_y: Coordinate }, { additionalProperties: false }),
-  press_key: Type.Object({ app: App, key: Type.String({ minLength: 1, maxLength: 100, description: "Key or combination; common aliases such as CMD+A are normalized to the official xdotool-style Meta_L+a form" }) }, { additionalProperties: false }),
-  type_text: Type.Object({ app: App, text: Type.String({ maxLength: 20_000 }) }, { additionalProperties: false }),
+  drag: Type.Object({
+    app: App,
+    from_x: Type.Number({ description: "Start X coordinate" }),
+    from_y: Type.Number({ description: "Start Y coordinate" }),
+    to_x: Type.Number({ description: "End X coordinate" }),
+    to_y: Type.Number({ description: "End Y coordinate" }),
+  }, { additionalProperties: false }),
+  press_key: Type.Object({ app: App, key: Type.String({ description: "Key or key combination to press" }) }, { additionalProperties: false }),
+  type_text: Type.Object({ app: App, text: Type.String({ description: "Literal text to type" }) }, { additionalProperties: false }),
 };
 
 function toolDescription(method: DirectMethod): string {
-  return `Call the official signed Computer Use ${method} capability directly through the unrestricted no-permissions interface. Pi supplies the typed arguments itself; there is no wrapper approval prompt, mode gate, nested model, planner, prompt, or separate model-token usage.`;
+  return OFFICIAL_TOOL_METADATA[method].description;
 }
 
 function titleFor(method: DirectMethod): string {
@@ -96,8 +108,7 @@ export default function directComputerUse(pi: ExtensionAPI) {
       promptSnippet: `${titleFor(method)} through the official signed macOS Computer Use service`,
       promptGuidelines: [
         `${piName} is a direct typed tool: choose its arguments yourself; it does not invoke a nested planner or model.`,
-        `${piName} must use current element identifiers from computer_use_get_app_state; inspect again after UI state changes.`,
-        `${piName} must not be used for credentials, authentication, payments, external messages, or destructive actions without the user's explicit request; this wrapper will not open a permission prompt.`,
+        `Call computer_use_get_app_state once per assistant turn before interacting with an app.`,
       ],
       parameters: ToolParameters[method] as any,
       async execute(_toolCallId, params, signal, onUpdate) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { CallToolResult, ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import {
+	CallToolRequestSchema,
+	ErrorCode,
+	ListToolsRequestSchema,
+	McpError,
+	type CallToolResult,
+	type ContentBlock,
+} from "@modelcontextprotocol/sdk/types.js";
 import { executeDirectTool, getDirectStatus } from "./direct-service.ts";
 import {
-	DIRECT_TOOL_SCHEMAS,
-	MUTATING_METHODS,
+	EXPECTED_OFFICIAL_INPUT_SCHEMAS,
+	isDirectMethod,
 	OFFICIAL_METHODS,
-	READ_ONLY_METHODS,
-	type DirectMethod,
+	OFFICIAL_TOOL_METADATA,
 } from "./tools.ts";
 
 const version = "0.2.0";
@@ -30,70 +36,61 @@ try {
 	process.exit(1);
 }
 
-const server = new McpServer(
+const server = new Server(
 	{ name: "codex-computer-use-mcp", version },
-	{ capabilities: { logging: {} } },
+	{ capabilities: { logging: {}, tools: {} } },
 );
 
-function titleFor(method: DirectMethod): string {
-	return method.split("_").map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`).join(" ");
-}
+const officialToolDefinitions = OFFICIAL_METHODS.map((method) => ({
+	name: method,
+	description: OFFICIAL_TOOL_METADATA[method].description,
+	inputSchema: EXPECTED_OFFICIAL_INPUT_SCHEMAS[method],
+	annotations: OFFICIAL_TOOL_METADATA[method].annotations,
+}));
 
-function descriptionFor(method: DirectMethod): string {
-	return `Call the official signed Computer Use ${method} capability directly through the unrestricted no-permissions interface. Pi/the MCP client supplies the typed arguments; no wrapper approval prompt, mode gate, nested model, prompt, planner, or model-token usage is involved.`;
-}
+const statusToolDefinition = {
+	name: "computer_use_status",
+	title: "Computer Use Status",
+	description: "Show direct-call architecture, durable no-permissions policy, signed broker status, supported methods, and private audit path.",
+	inputSchema: { type: "object" as const, properties: {}, additionalProperties: false },
+	annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+};
 
-for (const method of OFFICIAL_METHODS) {
-	server.registerTool(
-		method,
-		{
-			title: titleFor(method),
-			description: descriptionFor(method),
-			inputSchema: DIRECT_TOOL_SCHEMAS[method],
-			annotations: {
-				readOnlyHint: READ_ONLY_METHODS.has(method),
-				destructiveHint: MUTATING_METHODS.has(method),
-				idempotentHint: method === "list_apps" || method === "get_app_state",
-				openWorldHint: false,
-			},
-		},
-		async (toolArgs: Record<string, unknown>, extra: { signal?: AbortSignal }): Promise<CallToolResult> => {
-			try {
-				const response = await executeDirectTool(
-					{ method, arguments: toolArgs },
-					{ signal: extra.signal },
-				);
-				return {
-					content: response.content as ContentBlock[],
-					structuredContent: response.details,
-					isError: response.isError,
-				};
-			} catch (error) {
-				return {
-					content: [{ type: "text", text: error instanceof Error ? error.message : "Direct Computer Use failed" }],
-					isError: true,
-				};
-			}
-		},
-	);
-}
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+	tools: [...officialToolDefinitions, statusToolDefinition],
+}));
 
-server.registerTool(
-	"computer_use_status",
-	{
-		title: "Computer Use Status",
-		description: "Show direct-call architecture, permission mode, signed broker status, supported methods, and private audit path.",
-		annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-	},
-	async (): Promise<CallToolResult> => {
+server.setRequestHandler(CallToolRequestSchema, async (request, extra): Promise<CallToolResult> => {
+	if (request.params.name === statusToolDefinition.name) {
 		try {
 			const status = await getDirectStatus();
 			return { content: [{ type: "text", text: JSON.stringify(status, null, 2) }], structuredContent: status };
 		} catch (error) {
 			return { content: [{ type: "text", text: error instanceof Error ? error.message : "Could not read status" }], isError: true };
 		}
-	},
-);
+	}
+
+	if (!isDirectMethod(request.params.name)) {
+		throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${request.params.name}`);
+	}
+
+	try {
+		const response = await executeDirectTool(
+			{ method: request.params.name, arguments: request.params.arguments ?? {} },
+			{ signal: extra.signal },
+		);
+		return {
+			content: response.content as ContentBlock[],
+			structuredContent: response.details,
+			isError: response.isError,
+		};
+	} catch (error) {
+		return {
+			content: [{ type: "text", text: error instanceof Error ? error.message : "Direct Computer Use failed" }],
+			isError: true,
+		};
+	}
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 
-const app = z.string().trim().min(1).max(500).describe("App name, full app path, or unambiguous bundle identifier");
-const elementIndex = z.string().trim().min(1).max(200).describe("Element identifier from computer_use_get_app_state");
-const coordinate = z.number().finite().min(0).max(1_000_000);
+const app = z.string().describe("App name, full app path, or unambiguous bundle identifier");
+const selectTextApp = z.string().describe("App name or bundle identifier");
 
 export const DIRECT_TOOL_SCHEMAS = {
 	list_apps: z.object({}).strict(),
@@ -10,47 +9,131 @@ export const DIRECT_TOOL_SCHEMAS = {
 	click: z
 		.object({
 			app,
-			click_count: z.number().int().min(1).max(10).optional(),
-			element_index: elementIndex.optional(),
-			mouse_button: z.enum(["left", "right", "middle"]).optional(),
-			x: coordinate.optional(),
-			y: coordinate.optional(),
+			click_count: z.number().refine(Number.isInteger).describe("Number of clicks. Defaults to 1").optional(),
+			element_index: z.string().describe("Element index to click").optional(),
+			mouse_button: z.enum(["left", "right", "middle"]).describe("Mouse button to click. Defaults to left.").optional(),
+			x: z.number().describe("X coordinate in screenshot pixel coordinates").optional(),
+			y: z.number().describe("Y coordinate in screenshot pixel coordinates").optional(),
 		})
 		.strict(),
 	perform_secondary_action: z
-		.object({ app, element_index: elementIndex, action: z.string().trim().min(1).max(200) })
-		.strict(),
-	set_value: z.object({ app, element_index: elementIndex, value: z.string().max(20_000) }).strict(),
-	select_text: z
 		.object({
 			app,
-			element_index: elementIndex,
-			text: z.string().min(1).max(20_000),
-			prefix: z.string().max(2_000).optional(),
-			selection: z.enum(["text", "cursor_before", "cursor_after"]).optional(),
-			suffix: z.string().max(2_000).optional(),
+			element_index: z.string().describe("Element identifier"),
+			action: z.string().describe("Secondary accessibility action name"),
+		})
+		.strict(),
+	set_value: z
+		.object({
+			app,
+			element_index: z.string().describe("Element identifier"),
+			value: z.string().describe("Value to assign"),
+		})
+		.strict(),
+	select_text: z
+		.object({
+			app: selectTextApp,
+			element_index: z.string().describe("Text element identifier"),
+			text: z.string().describe("Target text as shown in the accessibility tree"),
+			prefix: z.string().describe("Optional text immediately before the target, used to disambiguate repeated matches").optional(),
+			selection: z.enum(["text", "cursor_before", "cursor_after"]).describe("Whether to select the text or place the cursor before or after it. Defaults to text.").optional(),
+			suffix: z.string().describe("Optional text immediately after the target, used to disambiguate repeated matches").optional(),
 		})
 		.strict(),
 	scroll: z
 		.object({
 			app,
-			element_index: elementIndex,
-			direction: z.enum(["up", "down", "left", "right"]),
-			pages: z.number().finite().positive().max(100).optional(),
+			element_index: z.string().describe("Element identifier"),
+			direction: z.string().describe("Scroll direction: up, down, left, or right"),
+			pages: z.number().describe("Number of pages to scroll. Fractional values are supported. Defaults to 1").optional(),
 		})
 		.strict(),
 	drag: z
-		.object({ app, from_x: coordinate, from_y: coordinate, to_x: coordinate, to_y: coordinate })
+		.object({
+			app,
+			from_x: z.number().describe("Start X coordinate"),
+			from_y: z.number().describe("Start Y coordinate"),
+			to_x: z.number().describe("End X coordinate"),
+			to_y: z.number().describe("End Y coordinate"),
+		})
 		.strict(),
-	press_key: z.object({ app, key: z.string().trim().min(1).max(100).describe("Official xdotool-style key name or combination, for example Meta_L+a, Return, or Escape") }).strict(),
-	type_text: z.object({ app, text: z.string().max(20_000) }).strict(),
+	press_key: z.object({ app, key: z.string().describe("Key or key combination to press") }).strict(),
+	type_text: z.object({ app, text: z.string().describe("Literal text to type") }).strict(),
 } as const;
 
 export type DirectMethod = keyof typeof DIRECT_TOOL_SCHEMAS;
 export type DirectToolArguments = Record<string, unknown>;
 
 export const OFFICIAL_METHODS = Object.freeze(Object.keys(DIRECT_TOOL_SCHEMAS) as DirectMethod[]);
-export const READ_ONLY_METHODS = new Set<DirectMethod>(["list_apps", "get_app_state"]);
+
+export interface OfficialToolMetadata {
+	description: string;
+	annotations: {
+		destructiveHint: boolean;
+		idempotentHint: boolean;
+		openWorldHint: boolean;
+		readOnlyHint: boolean;
+	};
+}
+
+const readAnnotations = Object.freeze({
+	destructiveHint: false,
+	idempotentHint: true,
+	openWorldHint: false,
+	readOnlyHint: true,
+});
+const actionAnnotations = Object.freeze({
+	destructiveHint: false,
+	idempotentHint: false,
+	openWorldHint: false,
+	readOnlyHint: false,
+});
+
+/** Exact upstream descriptions and annotations exposed by the signed Computer Use helper. */
+export const OFFICIAL_TOOL_METADATA: Readonly<Record<DirectMethod, OfficialToolMetadata>> = Object.freeze({
+	list_apps: {
+		description: "List the apps on this computer. Returns the set of apps that are currently running, as well as any that have been used in the last 14 days, including details on usage frequency",
+		annotations: readAnnotations,
+	},
+	get_app_state: {
+		description: "Start an app use session if needed, then get the state of the app's key window and return a screenshot and accessibility tree. This must be called once per assistant turn before interacting with the app",
+		annotations: readAnnotations,
+	},
+	click: {
+		description: "Click an element by index or pixel coordinates from screenshot",
+		annotations: actionAnnotations,
+	},
+	perform_secondary_action: {
+		description: "Invoke a secondary accessibility action exposed by an element",
+		annotations: actionAnnotations,
+	},
+	set_value: {
+		description: "Set the value of a settable accessibility element",
+		annotations: actionAnnotations,
+	},
+	select_text: {
+		description: "Select text inside a text element, or place the text cursor before or after it. Provide text exactly as it appears in the accessibility tree, including any Markdown formatting. If the text is not unique, provide surrounding prefix or suffix text to disambiguate it.",
+		annotations: actionAnnotations,
+	},
+	scroll: {
+		description: "Scroll an element in a direction by a number of pages",
+		annotations: actionAnnotations,
+	},
+	drag: {
+		description: "Drag from one point to another using pixel coordinates",
+		annotations: actionAnnotations,
+	},
+	press_key: {
+		description: "Press a key or key-combination on the keyboard, including modifier and navigation keys.\n  - This supports xdotool's `key` syntax.\n  - Examples: \"a\", \"Return\", \"Tab\", \"super+c\", \"Up\", \"KP_0\" (for the numpad 0 key).",
+		annotations: actionAnnotations,
+	},
+	type_text: {
+		description: "Type literal text using keyboard input",
+		annotations: actionAnnotations,
+	},
+});
+
+export const READ_ONLY_METHODS = new Set<DirectMethod>(OFFICIAL_METHODS.filter((method) => OFFICIAL_TOOL_METADATA[method].annotations.readOnlyHint));
 export const MUTATING_METHODS = new Set<DirectMethod>(OFFICIAL_METHODS.filter((method) => !READ_ONLY_METHODS.has(method)));
 
 export function isDirectMethod(value: string): value is DirectMethod {

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { OFFICIAL_METHODS } from "../src/tools.ts";
+import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA } from "../src/tools.ts";
 
 test("stdio MCP advertises one unrestricted no-permissions interface with all ten direct tools", async () => {
 	const stateRoot = await mkdtemp(path.join(os.tmpdir(), "direct-computer-use-mcp-test."));
@@ -23,9 +23,12 @@ test("stdio MCP advertises one unrestricted no-permissions interface with all te
 		assert.deepEqual(listed.tools.map((tool) => tool.name).sort(), [...OFFICIAL_METHODS, "computer_use_status"].sort());
 		for (const method of OFFICIAL_METHODS) {
 			const tool = listed.tools.find((item) => item.name === method)!;
-			assert.match(tool.description ?? "", /unrestricted no-permissions interface/i);
-			assert.match(tool.description ?? "", /no wrapper approval prompt/i);
-			assert.equal(tool.annotations?.readOnlyHint, method === "list_apps" || method === "get_app_state");
+			assert.deepEqual(tool, {
+				name: method,
+				description: OFFICIAL_TOOL_METADATA[method].description,
+				inputSchema: EXPECTED_OFFICIAL_INPUT_SCHEMAS[method],
+				annotations: OFFICIAL_TOOL_METADATA[method].annotations,
+			});
 		}
 
 		const status = await client.callTool({ name: "computer_use_status", arguments: {} });

--- a/test/official-broker.test.ts
+++ b/test/official-broker.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import test from "node:test";
 import { COMPUTER_USE_CLIENT_PATH, verifyOfficialDirectBroker } from "../src/direct-broker.ts";
-import { OFFICIAL_METHODS } from "../src/tools.ts";
+import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA } from "../src/tools.ts";
 
 function rpc(proc: ReturnType<typeof spawn>, id: number, method: string, params: unknown): Promise<any> {
 	proc.stdin!.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
@@ -43,6 +43,15 @@ test("official signed app-server broker and exact ten-tool helper inventory are 
 		proc.stdin!.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`);
 		const listed = await rpc(proc, 2, "tools/list", {});
 		assert.deepEqual(listed.result.tools.map((tool: any) => tool.name), OFFICIAL_METHODS);
+		for (const method of OFFICIAL_METHODS) {
+			const tool = listed.result.tools.find((item: any) => item.name === method);
+			assert.deepEqual(tool, {
+				name: method,
+				description: OFFICIAL_TOOL_METADATA[method].description,
+				inputSchema: EXPECTED_OFFICIAL_INPUT_SCHEMAS[method],
+				annotations: OFFICIAL_TOOL_METADATA[method].annotations,
+			});
+		}
 	} finally {
 		proc.kill("SIGTERM");
 		await new Promise<void>((resolve) => proc.once("close", () => resolve()));

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { OFFICIAL_METHODS } from "../src/tools.ts";
+import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA } from "../src/tools.ts";
 
 test("Pi adapter registers all ten tools through one no-permissions path with no prompt or mode route", async () => {
 	const source = await readFile("integrations/pi/index.ts", "utf8");
@@ -23,23 +23,36 @@ test("Pi adapter registers all ten tools through one no-permissions path with no
 		"ctx.ui.input",
 		"full-permissions",
 		"safe mode",
+		"must not be used",
+		"credentials",
+		"authentication",
+		"payments",
+		"external messages",
+		"destructive actions",
+		"purpose-built",
+		"confirmation",
+		"policy gate",
 	]) {
 		assert.doesNotMatch(source, new RegExp(forbidden.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
 	}
-	assert.match(source, /unrestricted no-permissions interface/);
-	assert.match(source, /no wrapper approval prompt/);
+	assert.match(source, /OFFICIAL_TOOL_METADATA\[method\]\.description/);
 	assert.match(source, /executeDirectTool/);
-	assert.match(source, /computer_use_get_app_state/);
+	assert.match(source, /Call computer_use_get_app_state once per assistant turn before interacting with an app/);
 });
 
-test("Pi runtime registration exposes exactly status plus all ten tools", async () => {
+test("Pi runtime registration exposes the exact official contract for all ten tools", async () => {
 	const { default: adapter } = await import("../integrations/pi/index.ts");
-	const tools: string[] = [];
+	const tools: Array<{ name: string; description: string; parameters: unknown; promptGuidelines: string[] }> = [];
 	const commands: string[] = [];
 	adapter({
-		registerTool(tool: { name: string }) { tools.push(tool.name); },
+		registerTool(tool: { name: string; description: string; parameters: unknown; promptGuidelines: string[] }) { tools.push(tool); },
 		registerCommand(name: string) { commands.push(name); },
 	} as any);
 	assert.deepEqual(commands, ["computer-use-status"]);
-	assert.deepEqual(tools.sort(), OFFICIAL_METHODS.map((method) => `computer_use_${method}`).sort());
+	assert.deepEqual(tools.map((tool) => tool.name).sort(), OFFICIAL_METHODS.map((method) => `computer_use_${method}`).sort());
+	for (const method of OFFICIAL_METHODS) {
+		const tool = tools.find((item) => item.name === `computer_use_${method}`)!;
+		assert.equal(tool.description, OFFICIAL_TOOL_METADATA[method].description);
+		assert.deepEqual(tool.parameters, EXPECTED_OFFICIAL_INPUT_SCHEMAS[method]);
+	}
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { normalizeKeyExpression, validateDirectArguments } from "../src/tools.ts";
+import { OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA, normalizeKeyExpression, validateDirectArguments } from "../src/tools.ts";
 
 test("common Pi key aliases normalize to the official xdotool-style key table", () => {
 	assert.equal(normalizeKeyExpression("CMD+A"), "Meta_L+a");
@@ -12,4 +12,29 @@ test("common Pi key aliases normalize to the official xdotool-style key table", 
 		key: "Meta_L+a",
 	});
 	assert.deepEqual(validateDirectArguments("click", { app: "TextEdit" }), { app: "TextEdit" });
+});
+
+test("wrapper validation adds no limits or enums absent from the official schemas", () => {
+	assert.deepEqual(validateDirectArguments("click", {
+		app: "TextEdit",
+		click_count: 100_000_000_000_000_000_000,
+		x: -50,
+		y: 2_000_000,
+	}), { app: "TextEdit", click_count: 100_000_000_000_000_000_000, x: -50, y: 2_000_000 });
+	assert.deepEqual(validateDirectArguments("scroll", {
+		app: "TextEdit",
+		element_index: "scroll-area",
+		direction: "diagonal",
+		pages: -2,
+	}), { app: "TextEdit", element_index: "scroll-area", direction: "diagonal", pages: -2 });
+	assert.deepEqual(validateDirectArguments("type_text", {
+		app: "TextEdit",
+		text: "x".repeat(25_000),
+	}), { app: "TextEdit", text: "x".repeat(25_000) });
+});
+
+test("official action metadata does not conflate mutation with destruction", () => {
+	for (const method of OFFICIAL_METHODS) {
+		assert.equal(OFFICIAL_TOOL_METADATA[method].annotations.destructiveHint, false);
+	}
 });


### PR DESCRIPTION
## Summary
- expose the signed helper descriptions, input schemas, and annotations verbatim through MCP
- remove wrapper-only argument limits, action warnings, approval rhetoric, and stale generic descriptions from the Pi surface
- enforce full contract parity against the live signed helper and both façades in tests

## Verification
- `npm run prepublishOnly`
- `npm pack --dry-run`
- 47/47 tests pass, including the live signed-helper contract check