### PR TITLE
fix: forward official Computer Use elicitations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,7 @@ nested prompts or result summaries
 | Wrapper app/intent allowlists in full mode | **accidental** | absent |
 | Safe/full wrapper modes | **compatibility-only** | removed; one durable no-permissions interface exposes all ten methods |
 | Wrapper approval prompts/configuration | **compatibility-only** | removed; no command, config, environment, or per-call selector remains |
-| Official first-party app access | **official-required** | remains external to this wrapper; unexpected elicitations are silently declined and never auto-accepted |
+| Official first-party app access | **official-required** | signed service elicitations are forwarded to the invoking client; never auto-accepted or silently declined |
 | macOS TCC | **official-required** | retained; never modified |
 | Exact ten-tool inventory/schema | **security-essential** | retained and checked before each call |
 | Canonical bundle identity | **security-essential** | retained before targeted dispatch |
@@ -121,7 +121,7 @@ nested prompts or result summaries
 
 No-permissions is the sole interface and means unrestricted wrapper dispatch with no wrapper approval prompt. All ten methods are registered. No config file, environment value, slash command, CLI mode switch, or tool argument selects another route.
 
-Both Pi and generic stdio MCP omit elicitation capability. App-server is created with `approvalPolicy: "never"`. If the official downstream server nevertheless sends an elicitation request, the bridge counts and silently declines it; there is no UI path and no acceptance callback. Users configure any persistent first-party app access externally in official ChatGPT Computer Use settings.
+App-server is created with `approvalPolicy: "never"` so the wrapper does not generate Codex approval prompts. The broker still handles `mcpServer/elicitation/request` from the signed downstream service. Pi advertises OpenAI-form support and renders form, OpenAI-form, and URL requests through its UI. Generic stdio MCP forwards standard form and URL requests as `elicitation/create` to the invoking MCP client. The response path preserves `accept`, `decline`, `cancel`, structured content, and response metadata; no callback or compatible UI yields `cancel`, never an invented decline.
 
 ## Output boundary
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -35,7 +35,7 @@ CODEX_COMPUTER_USE_HOME="$(mktemp -d)" \
 
 `-ne` suppresses auto-discovered extensions so the live 0.1 adapter is not loaded. This does not change live Pi configuration.
 
-The source adapter starts only in no-permissions mode: all ten methods are available and the wrapper opens no approval UI. Use only benign real apps whose persistent first-party access is already configured. Do not use disposable harnesses as acceptance evidence.
+The source adapter starts only in no-permissions mode: all ten methods are available and the wrapper opens no permission UI of its own. Signed Computer Use elicitations are still shown through Pi and answered only by the user. Use benign real apps for acceptance; do not use disposable harnesses as evidence.
 
 ## Migrate to version 0.2.0
 
@@ -47,7 +47,8 @@ The source adapter starts only in no-permissions mode: all ten methods are avail
 6. Start a fresh Pi process; do not rely on hot-reloading a security-boundary change.
 7. Verify `/computer-use-status` reports:
    - `permissionMode: "no-permissions"`;
-   - `approvalPrompts: false`;
+   - `wrapperPermissionPrompts: false`;
+   - `officialElicitationHandling: "forwarded-when-client-supported"`;
    - all ten `availableMethods`;
    - `brokerVerified: true`;
    - `nestedModel: false`;

--- a/PROOF.md
+++ b/PROOF.md
@@ -71,7 +71,10 @@ Current branch tests cover:
 - global per-user same-app exclusion across different supported state roots, race behavior, crash release, private lock roots, and bounded lock filenames;
 - focus-event ASN retry/drain behavior, including valid events at the start of a single large stdout chunk;
 - stdio MCP all-ten inventory/status with no alternate mode route;
-- Pi source registration for every direct capability with no nested planner, permission command, or approval UI reference.
+- signed app-server elicitation forwarding, exact user responses, headless cancellation, and cancellation while a UI callback is pending;
+- standard form/URL forwarding across a real MCP SDK client/server transport;
+- Pi source registration for every direct capability with no nested planner, permission command, or wrapper-generated approval UI;
+- Pi form, opaque OpenAI-form, URL, decline, and headless-cancel elicitation handling.
 
 ## Fresh Pi unlocked real-app acceptance
 
@@ -119,7 +122,7 @@ Validation recorded for the reviewed direct implementation:
 - public-source scrub: no secrets, private absolute paths, or machine identifiers found;
 - fresh-Pi real-app acceptance: pass as above.
 
-Independent reviews of earlier revisions found cleanup and coordination gaps: fail-open or partial descendant enumeration, early-exit orphan recovery, state-root-scoped same-app locking, false-success lease-release audit, unverified focus-listener exit, pre-response direct-call accounting, and large-chunk focus-event loss. The reviewed implementation retains those fixes while removing all wrapper approval UI and safe or full configuration branches.
+Independent reviews of earlier revisions found cleanup and coordination gaps: fail-open or partial descendant enumeration, early-exit orphan recovery, state-root-scoped same-app locking, false-success lease-release audit, unverified focus-listener exit, pre-response direct-call accounting, and large-chunk focus-event loss. The reviewed implementation retains those fixes while removing wrapper-generated approval UI and safe or full configuration branches. Signed official-service elicitations remain a separate, forwarded user interaction.
 
 Version 0.2.0 supports direct local calls only in an unlocked macOS session. Targeted calls failed with official error `-10005` during genuine locked-session acceptance. OpenAI limits locked Computer Use to active trusted turns started from a connected device, so locked local use remains follow-up work and is not part of this release.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ As the official contract specifies, Pi—not a nested planner—calls `computer_
 
 `no-permissions` has one precise meaning here: **the wrapper asks no permission questions and exposes all ten official actions**. It is the only mode and the durable default. There is no safe/full selector, config file, environment override, slash command, CLI switch, per-call elevation, app allowlist, intent classifier, task schema, per-action confirmation, special-case app policy, or method gate.
 
-The app-server runtime is also created with `approvalPolicy: "never"`. The client does not advertise an elicitation UI. If the official downstream service unexpectedly requests elicitation, the bridge silently declines it; it never opens a prompt and never self-accepts. Any persistent first-party access required by Computer Use must therefore already be configured in the official ChatGPT app.
+The app-server runtime is also created with `approvalPolicy: "never"`, which removes host-generated Codex approval prompts. It does not suppress requests from the signed Computer Use service. When that service sends `mcpServer/elicitation/request`, the bridge forwards the request to the invoking client and returns that client's `accept`, `decline`, or `cancel` response. It never fabricates a permission prompt, accepts on the user's behalf, or silently converts a request into a decline. A headless or elicitation-incompatible client returns `cancel`, matching Codex's non-interactive behavior.
 
 No-permissions does **not** bypass:
 
@@ -67,7 +67,7 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for source links and the full restricti
 - macOS
 - Node.js 22 or newer
 - official ChatGPT macOS app at `/Applications/ChatGPT.app`
-- official Computer Use component installed and its first-party permissions configured
+- official Computer Use component installed
 
 The direct bridge starts app-server with a new private `CODEX_HOME` containing no account credentials and only one configured MCP server: official Computer Use. It does not inherit the user's Codex MCP servers, plugins, history, memories, API keys, or auth file. It selects a non-websocket dummy model provider bound to unreachable loopback, disables plugin/remote-control features, and never starts a turn; this prevents app-server model prewarm or Responses API traffic.
 
@@ -99,7 +99,7 @@ Command:
 /computer-use-status
 ```
 
-The native Pi adapter is the primary product path. It always registers all ten typed tools directly. It exposes no mode-changing command and no approval UI.
+The native Pi adapter is the primary product path. It always registers all ten typed tools directly and exposes no mode-changing command or wrapper-generated approval UI. Signed Computer Use form, OpenAI-form, and URL elicitations are shown through Pi's UI; only the user's choice is returned to the service.
 
 ## MCP server
 
@@ -125,7 +125,7 @@ For Pi's generic MCP gateway, keep `directTools: false` so this powerful surface
 }
 ```
 
-The generic MCP server exposes the same no-permissions behavior: no wrapper approval UI and all ten methods. Unexpected downstream elicitations are silently declined; configure persistent first-party app access only in official ChatGPT Computer Use settings.
+The generic MCP server exposes the same no-permissions behavior: no wrapper permission gate and all ten methods. Standard form and URL elicitations from the signed service are forwarded as MCP `elicitation/create` requests. The upstream client response is returned unchanged; unsupported or headless clients cancel rather than fabricate a decline.
 
 ## Security and privacy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ This is direct tool dispatch—not model orchestration.
 3. The helper's exact ten method names and input schemas match the pinned expected inventory before every call; release tests also verify its descriptions and annotations.
 4. `no-permissions` is the only wrapper policy: all ten methods are exposed and no wrapper permission prompt is opened.
 5. There is no config file, environment override, command, tool argument, per-call branch, or alternate safe/full route that an agent can select.
-6. App-server uses `approvalPolicy: "never"`; elicitation capability is disabled and unexpected first-party requests are silently declined, never prompted or self-accepted. Persistent official app access remains authoritative and must be configured outside this wrapper.
+6. App-server uses `approvalPolicy: "never"` to disable host-generated Codex approvals. Signed downstream elicitations remain authoritative: Pi renders them, generic MCP forwards standard form/URL requests to its client, and the bridge returns the resulting `accept`, `decline`, or `cancel`. It never invents, silently declines, or self-accepts them; an unavailable client cancels.
 7. Target selectors resolve to canonical installed bundle IDs before dispatch.
 8. Same-app work is excluded across native Pi, generic MCP, and custom state roots with one fixed per-user kernel `lockf` lease namespace.
 9. Target focus events, periodic samples, watcher health, queued ASN resolution, and final state are checked. This is post-action detection, not a preventive OS sandbox.
@@ -46,7 +46,7 @@ The mode is compiled as the sole policy. Agent-writable audit state and legacy c
 
 ## Elicitations
 
-Neither Pi nor stdio MCP advertises or renders an approval UI. The bridge starts app-server with `approvalPolicy: "never"`. An unexpected downstream elicitation is counted, silently declined, and never self-accepted. Persistent first-party app access belongs in official ChatGPT Computer Use settings.
+The bridge starts app-server with `approvalPolicy: "never"`, so it does not create Codex host approval prompts. This is separate from the signed Computer Use service's own elicitations. Pi advertises and renders the service's form, OpenAI-form, and URL requests. Stdio MCP forwards standard form and URL requests through `elicitation/create`. Only a user or upstream client response can produce `accept` or `decline`; cancellation, missing UI, unsupported modes, and unsupported clients produce `cancel`.
 
 ## Visible content
 

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -35,7 +35,7 @@ Use the source workflow only when you need to test an exact reviewed commit. Fol
 - `computer_use_type_text`
 - `/computer-use-status`
 
-No-permissions is the only policy: all ten tools are available with no wrapper approval prompts, mode selector, or app/intent/action gate. Pi does not advertise or render elicitation UI. Unexpected downstream elicitations are silently declined and never accepted.
+No-permissions is the only policy: all ten tools are available with no wrapper permission prompts, mode selector, or app/intent/action gate. Pi advertises support for signed Computer Use elicitations and renders form, OpenAI-form, and URL requests through its UI. The user's `accept`, `decline`, or `cancel` response is returned to the service; the adapter never fabricates or silently answers one.
 
 ## Generic MCP gateway
 
@@ -59,6 +59,6 @@ For a source checkout:
 
 Do not load the native adapter and generic MCP adapter into the same acceptance process unless tool names are intentionally isolated.
 
-The generic MCP path uses the same durable no-permissions policy: all ten methods, no wrapper approval UI, and silent decline of unexpected downstream elicitations. Configure persistent app access only through official ChatGPT Computer Use settings.
+The generic MCP path uses the same durable no-permissions policy: all ten methods and no wrapper permission gate. Standard form and URL elicitations are forwarded to the invoking MCP client; an unsupported or headless client returns `cancel` rather than a fabricated decline.
 
 See the root `MIGRATION.md` before replacing an installed 0.1 adapter.

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -4,6 +4,10 @@ import { getAgentDir, truncateHead, type ExtensionAPI } from "@earendil-works/pi
 import { Text } from "@earendil-works/pi-tui";
 import { Type, type TSchema } from "typebox";
 import { executeDirectTool, getDirectStatus } from "../../dist/direct-service.js";
+import type {
+  DirectBrokerElicitationRequest,
+  DirectBrokerElicitationResponse,
+} from "../../dist/direct-broker.js";
 import { OFFICIAL_TOOL_METADATA, type DirectMethod } from "../../dist/tools.js";
 
 const App = Type.String({ description: "App name, full app path, or unambiguous bundle identifier" });
@@ -87,6 +91,74 @@ function errorText(content: Array<Record<string, unknown>>): string {
     .slice(0, 2_000) || "Official Computer Use returned an error";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function initialFormContent(schema: unknown): Record<string, unknown> {
+  if (!isRecord(schema) || !isRecord(schema.properties)) return {};
+  const content: Record<string, unknown> = {};
+  for (const [key, rawProperty] of Object.entries(schema.properties)) {
+    if (!isRecord(rawProperty)) continue;
+    if (rawProperty.default !== undefined) content[key] = rawProperty.default;
+    else if (Array.isArray(rawProperty.enum) && rawProperty.enum.length > 0) content[key] = rawProperty.enum[0];
+    else if (rawProperty.type === "boolean") content[key] = false;
+    else if (rawProperty.type === "number" || rawProperty.type === "integer") content[key] = 0;
+    else if (rawProperty.type === "array") content[key] = [];
+    else content[key] = "";
+  }
+  return content;
+}
+
+export async function handleOfficialElicitation(
+  request: DirectBrokerElicitationRequest,
+  ctx: { hasUI: boolean; ui: {
+    select(title: string, options: string[]): Promise<string | undefined>;
+    editor(title: string, prefill?: string): Promise<string | undefined>;
+    notify(message: string, type?: "info" | "warning" | "error"): void;
+  } },
+  openUrl: (url: string) => Promise<boolean>,
+): Promise<DirectBrokerElicitationResponse> {
+  if (!ctx.hasUI) return { action: "cancel" };
+  const message = typeof request.message === "string" ? request.message : "Official Computer Use requests input";
+
+  if (request.mode === "url") {
+    if (typeof request.url !== "string") return { action: "cancel" };
+    const choice = await ctx.ui.select(`${message}\n${request.url}`, ["Open URL", "Decline", "Cancel"]);
+    if (choice === "Decline") return { action: "decline" };
+    if (choice !== "Open URL") return { action: "cancel" };
+    if (!await openUrl(request.url)) {
+      ctx.ui.notify("Could not open the official Computer Use URL.", "error");
+      return { action: "cancel" };
+    }
+    return { action: "accept" };
+  }
+
+  if (request.mode !== undefined && request.mode !== "form" && request.mode !== "openai/form") {
+    ctx.ui.notify(`Official Computer Use sent an unsupported elicitation mode: ${request.mode}`, "warning");
+    return { action: "cancel" };
+  }
+  const openAiForm = request.mode === "openai/form";
+  if (request.requestedSchema === undefined || (!openAiForm && !isRecord(request.requestedSchema))) return { action: "cancel" };
+  const choice = await ctx.ui.select(message, ["Respond", "Decline", "Cancel"]);
+  if (choice === "Decline") return { action: "decline" };
+  if (choice !== "Respond") return { action: "cancel" };
+  let prefill = JSON.stringify(initialFormContent(request.requestedSchema), null, 2);
+  const title = `${message}\nSchema: ${JSON.stringify(request.requestedSchema)}`;
+  while (true) {
+    const edited = await ctx.ui.editor(title, prefill);
+    if (edited === undefined) return { action: "cancel" };
+    prefill = edited;
+    try {
+      const content = JSON.parse(edited);
+      if (!openAiForm && !isRecord(content)) throw new Error("Response must be a JSON object");
+      return { action: "accept", content };
+    } catch (error) {
+      ctx.ui.notify(error instanceof Error ? error.message : "Response must be valid JSON", "error");
+    }
+  }
+}
+
 export default function directComputerUse(pi: ExtensionAPI) {
   const stateRoot = process.env.CODEX_COMPUTER_USE_HOME || path.join(getAgentDir(), "direct-computer-use");
 
@@ -111,12 +183,21 @@ export default function directComputerUse(pi: ExtensionAPI) {
         `Call computer_use_get_app_state once per assistant turn before interacting with an app.`,
       ],
       parameters: ToolParameters[method] as any,
-      async execute(_toolCallId, params, signal, onUpdate) {
+      async execute(_toolCallId, params, signal, onUpdate, ctx) {
         const response = await executeDirectTool(
           { method, arguments: params as Record<string, unknown> },
           {
             stateRoot,
             signal,
+            supportsOpenAiFormElicitation: true,
+            onElicitation: (request) => handleOfficialElicitation(
+              request,
+              ctx,
+              async (url) => {
+                const result = await pi.exec("/usr/bin/open", ["--", url], { signal, timeout: 15_000 });
+                return result.code === 0;
+              },
+            ),
             onProgress: (message) => onUpdate?.({ content: [{ type: "text", text: message }], details: { status: "running" } }),
           },
         );

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -20,7 +20,7 @@ export interface AuditRecord {
 	directCalls: number;
 	modelTurnsStarted: number;
 	ephemeralThread: boolean | null;
-	approvalRequests: number;
+	elicitationRequests: number;
 	backgroundPreserved: boolean | null;
 	brokerCleanupVerified: boolean;
 	appLeaseReleased: boolean;

--- a/src/direct-broker.ts
+++ b/src/direct-broker.ts
@@ -17,6 +17,20 @@ const OPENAI_TEAM_ID = "2DC432GLL2";
 const MAX_PROTOCOL_LINE_BYTES = 8 * 1024 * 1024;
 const MAX_RESULT_BYTES = 25 * 1024 * 1024;
 
+export interface DirectBrokerElicitationRequest extends Record<string, unknown> {
+	mode?: string;
+	message?: string;
+	requestedSchema?: unknown;
+	url?: string;
+	elicitationId?: string;
+}
+
+export interface DirectBrokerElicitationResponse {
+	action: "accept" | "decline" | "cancel";
+	content?: unknown;
+	_meta?: unknown;
+}
+
 export interface DirectBrokerResult {
 	content: Array<Record<string, unknown>>;
 	structuredContent?: unknown;
@@ -24,7 +38,7 @@ export interface DirectBrokerResult {
 	brokerVersion: string;
 	clientBuild: string;
 	durationMs: number;
-	approvalRequests: number;
+	elicitationRequests: number;
 	modelTurnsStarted: 0;
 	ephemeralThread: true;
 	brokerCleanupVerified: true;
@@ -33,6 +47,10 @@ export interface DirectBrokerResult {
 export interface DirectBrokerOptions {
 	timeoutMs?: number;
 	signal?: AbortSignal;
+	onElicitation?: (
+		request: DirectBrokerElicitationRequest,
+	) => DirectBrokerElicitationResponse | Promise<DirectBrokerElicitationResponse>;
+	supportsOpenAiFormElicitation?: boolean;
 	/** Test-only executable override. Production callers never set this. */
 	appServerCommand?: string;
 	/** Test-only argument override. */
@@ -58,7 +76,7 @@ export class DirectBrokerCallError extends Error {
 	readonly directCalls: number;
 	readonly modelTurnsStarted: number;
 	readonly ephemeralThread: boolean;
-	readonly approvalRequests: number;
+	readonly elicitationRequests: number;
 	readonly brokerVersion: string;
 	readonly clientBuild: string;
 	constructor(
@@ -69,7 +87,7 @@ export class DirectBrokerCallError extends Error {
 			directCalls?: number;
 			modelTurnsStarted?: number;
 			ephemeralThread?: boolean;
-			approvalRequests?: number;
+			elicitationRequests?: number;
 			brokerVersion?: string;
 			clientBuild?: string;
 		} = {},
@@ -80,7 +98,7 @@ export class DirectBrokerCallError extends Error {
 		this.directCalls = evidence.directCalls ?? 0;
 		this.modelTurnsStarted = evidence.modelTurnsStarted ?? 0;
 		this.ephemeralThread = evidence.ephemeralThread ?? false;
-		this.approvalRequests = evidence.approvalRequests ?? 0;
+		this.elicitationRequests = evidence.elicitationRequests ?? 0;
 		this.brokerVersion = evidence.brokerVersion ?? "unknown";
 		this.clientBuild = evidence.clientBuild ?? "unknown";
 	}
@@ -429,7 +447,7 @@ export async function callOfficialDirectTool(
 	let fatalError: Error | undefined;
 	let stderr = "";
 	let nextId = 1;
-	let approvalRequests = 0;
+	let elicitationRequests = 0;
 	let modelTurnsStarted = 0;
 	let directCalls = 0;
 	let ephemeralThread = false;
@@ -527,14 +545,23 @@ export async function callOfficialDirectTool(
 						send({ id: message.id, error: { code: -32601, message: "Unsupported server request" } });
 						return;
 					}
-					if (approvalRequests >= 8) {
-						fail(new Error("Official app-server emitted excessive elicitation requests"));
-						return;
-					}
-					approvalRequests += 1;
-					// The durable no-permissions interface never opens an approval UI and never
-					// self-accepts a first-party request. Unexpected elicitations are declined.
-					send({ id: message.id, result: { action: "decline" } });
+					elicitationRequests += 1;
+					const requestParams = message.params && typeof message.params === "object" && !Array.isArray(message.params)
+						? message.params as DirectBrokerElicitationRequest
+						: {};
+					void (async () => {
+						let response: DirectBrokerElicitationResponse = { action: "cancel" };
+						if (options.onElicitation) {
+							try {
+								const candidate = await options.onElicitation(requestParams);
+								if (candidate && ["accept", "decline", "cancel"].includes(candidate.action)) response = candidate;
+							} catch {
+								response = { action: "cancel" };
+							}
+						}
+						if (fatalError || !proc?.stdin.writable) return;
+						send({ id: message.id, result: response });
+					})().catch((error) => fail(error instanceof Error ? error : new Error(String(error))));
 					return;
 				}
 			} catch (error) {
@@ -580,7 +607,7 @@ export async function callOfficialDirectTool(
 			"initialize",
 			{
 				clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.2.0" },
-				capabilities: { mcpServerOpenaiFormElicitation: false },
+				capabilities: { mcpServerOpenaiFormElicitation: options.supportsOpenAiFormElicitation === true && options.onElicitation !== undefined },
 			},
 			15_000,
 		);
@@ -622,7 +649,7 @@ export async function callOfficialDirectTool(
 			brokerVersion: verification.brokerVersion,
 			clientBuild: verification.clientBuild,
 			durationMs: Date.now() - startedAt,
-			approvalRequests,
+			elicitationRequests,
 			modelTurnsStarted: 0,
 			ephemeralThread: true,
 			brokerCleanupVerified: true,
@@ -660,7 +687,7 @@ export async function callOfficialDirectTool(
 		directCalls,
 		modelTurnsStarted,
 		ephemeralThread,
-		approvalRequests,
+		elicitationRequests,
 		brokerVersion: verification.brokerVersion,
 		clientBuild: verification.clientBuild,
 	};

--- a/src/direct-service.ts
+++ b/src/direct-service.ts
@@ -7,6 +7,8 @@ import {
 	callOfficialDirectTool,
 	DirectBrokerCallError,
 	verifyOfficialDirectBroker,
+	type DirectBrokerElicitationRequest,
+	type DirectBrokerElicitationResponse,
 	type DirectBrokerResult,
 } from "./direct-broker.ts";
 import { acquireAppLock, globalAppLockRoot, type AppLock } from "./lock.ts";
@@ -44,6 +46,10 @@ export interface DirectServiceDependencies {
 	stateRoot?: string;
 	signal?: AbortSignal;
 	onProgress?: (message: string) => void | Promise<void>;
+	onElicitation?: (
+		request: DirectBrokerElicitationRequest,
+	) => DirectBrokerElicitationResponse | Promise<DirectBrokerElicitationResponse>;
+	supportsOpenAiFormElicitation?: boolean;
 	callTool?: typeof callOfficialDirectTool;
 	resolveIdentity?: typeof resolveAppIdentity;
 	frontmost?: typeof frontmostBundleId;
@@ -139,7 +145,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 			directCalls: 0,
 			modelTurnsStarted: 0,
 			ephemeralThread: null,
-			approvalRequests: 0,
+			elicitationRequests: 0,
 			backgroundPreserved: null,
 			brokerCleanupVerified: true,
 			appLeaseReleased: true,
@@ -160,7 +166,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 			app: auditAppIdentifier(rawApp, identity), mutating: MUTATING_METHODS.has(request.method),
 			authorization: authorizationFor(config.permissionMode, request.method), inputBytes: inputByteCount(request.arguments),
 			outcome: "identity_rejected", durationMs: Date.now() - startedAt, brokerVersion: null, clientBuild: null,
-			directCalls: 0, modelTurnsStarted: 0, ephemeralThread: null, approvalRequests: 0,
+			directCalls: 0, modelTurnsStarted: 0, ephemeralThread: null, elicitationRequests: 0,
 			backgroundPreserved: null, brokerCleanupVerified: true, appLeaseReleased: true, resultContentTypes: [], resultBytes: 0,
 		};
 		try { await appendAudit(stateRoot, audit); }
@@ -219,6 +225,8 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 			broker = await (deps.callTool ?? callOfficialDirectTool)(request.method, canonicalArgs, {
 				signal: deps.signal,
 				timeoutMs: 120_000,
+				onElicitation: deps.onElicitation,
+				supportsOpenAiFormElicitation: deps.supportsOpenAiFormElicitation,
 			});
 			brokerCleanupVerified = broker.brokerCleanupVerified;
 		} catch (error) {
@@ -245,7 +253,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 				directCalls: 1,
 				modelTurnsStarted: 0,
 				ephemeralRuntimeContext: true,
-				approvalRequests: broker.approvalRequests,
+				elicitationRequests: broker.elicitationRequests,
 				brokerVersion: broker.brokerVersion,
 				clientBuild: broker.clientBuild,
 				durationMs: broker.durationMs,
@@ -301,7 +309,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 			directCalls: broker ? 1 : brokerFailure?.directCalls ?? 0,
 			modelTurnsStarted: broker?.modelTurnsStarted ?? brokerFailure?.modelTurnsStarted ?? 0,
 			ephemeralThread: broker?.ephemeralThread ?? brokerFailure?.ephemeralThread ?? null,
-			approvalRequests: broker?.approvalRequests ?? brokerFailure?.approvalRequests ?? 0,
+			elicitationRequests: broker?.elicitationRequests ?? brokerFailure?.elicitationRequests ?? 0,
 			backgroundPreserved,
 			brokerCleanupVerified,
 			appLeaseReleased: !releaseFailed,
@@ -336,12 +344,13 @@ export async function getDirectStatus(stateRoot = defaultStateRoot()): Promise<R
 		brokerVerified,
 		...(brokerVersion ? { brokerVersion } : {}),
 		...(clientBuild ? { clientBuild } : {}),
-		officialApprovalAuthoritative: true,
+		officialElicitationsAuthoritative: true,
 		architecture: "official-codex-app-server-direct-mcp-tool-call",
 		nestedModel: false,
 		modelUsage: false,
 		ephemeralZeroTurnRuntimeContextRequired: true,
-		approvalPrompts: false,
+		wrapperPermissionPrompts: false,
+		officialElicitationHandling: "forwarded-when-client-supported",
 		wrapperAuthorization: "unrestricted",
 		availableMethods: [...OFFICIAL_METHODS],
 		supportedMethods: [...OFFICIAL_METHODS],

--- a/src/mcp-elicitation.ts
+++ b/src/mcp-elicitation.ts
@@ -1,0 +1,60 @@
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { ElicitRequestParams, ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+	DirectBrokerElicitationRequest,
+	DirectBrokerElicitationResponse,
+} from "./direct-broker.ts";
+
+export interface McpElicitationClient {
+	elicitInput(params: ElicitRequestParams, options?: RequestOptions): Promise<ElicitResult>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Forward a signed app-server elicitation over standard MCP without changing its meaning. */
+export async function forwardOfficialElicitationToMcpClient(
+	client: McpElicitationClient,
+	request: DirectBrokerElicitationRequest,
+	signal?: AbortSignal,
+): Promise<DirectBrokerElicitationResponse> {
+	let params: ElicitRequestParams;
+	if (request.mode === "url") {
+		if (
+			typeof request.message !== "string"
+			|| typeof request.url !== "string"
+			|| typeof request.elicitationId !== "string"
+		) return { action: "cancel" };
+		params = {
+			mode: "url",
+			message: request.message,
+			url: request.url,
+			elicitationId: request.elicitationId,
+			...(isRecord(request._meta) ? { _meta: request._meta } : {}),
+		};
+	} else if (request.mode === undefined || request.mode === "form") {
+		if (typeof request.message !== "string" || !isRecord(request.requestedSchema)) return { action: "cancel" };
+		params = {
+			mode: "form",
+			message: request.message,
+			requestedSchema: request.requestedSchema,
+			...(isRecord(request._meta) ? { _meta: request._meta } : {}),
+		} as ElicitRequestParams;
+	} else {
+		// OpenAI's richer openai/form mode is advertised only by clients that can render it.
+		return { action: "cancel" };
+	}
+
+	try {
+		const response = await client.elicitInput(params, signal ? { signal } : undefined);
+		return {
+			action: response.action,
+			...(response.content !== undefined ? { content: response.content } : {}),
+			...(isRecord(response._meta) ? { _meta: response._meta } : {}),
+		};
+	} catch {
+		// This is the MCP headless/unsupported-client outcome, not a fabricated decline.
+		return { action: "cancel" };
+	}
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10,6 +10,7 @@ import {
 	type ContentBlock,
 } from "@modelcontextprotocol/sdk/types.js";
 import { executeDirectTool, getDirectStatus } from "./direct-service.ts";
+import { forwardOfficialElicitationToMcpClient } from "./mcp-elicitation.ts";
 import {
 	EXPECTED_OFFICIAL_INPUT_SCHEMAS,
 	isDirectMethod,
@@ -77,7 +78,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra): Promise<
 	try {
 		const response = await executeDirectTool(
 			{ method: request.params.name, arguments: request.params.arguments ?? {} },
-			{ signal: extra.signal },
+			{
+				signal: extra.signal,
+				onElicitation: (elicitation) => forwardOfficialElicitationToMcpClient(server, elicitation, extra.signal),
+			},
 		);
 		return {
 			content: response.content as ContentBlock[],

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -21,7 +21,7 @@ const record: AuditRecord = {
 	directCalls: 1,
 	modelTurnsStarted: 0,
 	ephemeralThread: true,
-	approvalRequests: 0,
+	elicitationRequests: 0,
 	backgroundPreserved: true,
 	brokerCleanupVerified: true,
 	appLeaseReleased: true,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -22,7 +22,8 @@ test("CLI exposes durable no-permissions status and no mode-selection route", as
 		const { stdout } = await run(stateRoot, ["--status"]);
 		const status = JSON.parse(stdout);
 		assert.equal(status.permissionMode, "no-permissions");
-		assert.equal(status.approvalPrompts, false);
+		assert.equal(status.wrapperPermissionPrompts, false);
+		assert.equal(status.officialElicitationHandling, "forwarded-when-client-supported");
 		assert.equal(status.wrapperAuthorization, "unrestricted");
 		assert.equal(status.availableMethods.length, 10);
 		assert.equal(status.nestedModel, false);

--- a/test/direct-broker.test.ts
+++ b/test/direct-broker.test.ts
@@ -27,11 +27,11 @@ rl.on("line",line=>{const m=JSON.parse(line); appendFileSync(log,JSON.stringify(
  if(m.method==="mcpServerStatus/list"){const tools=JSON.parse(JSON.stringify(inventory)); if(mode==="schema-drift")tools.list_apps.inputSchema.properties={drift:{type:"string"}}; send({id:m.id,result:{data:[{name:"computer-use",tools}]}});if(mode==="close-before-tool"){process.stdin.destroy();setTimeout(()=>process.exit(0),100);}return;}
  if(m.method==="mcpServer/tool/call"){
    if(mode==="hang"||mode==="child-hang") return;
-   if(mode==="elicit"){pendingTool=m.id; return send({id:"approval-1",method:"mcpServer/elicitation/request",params:{mode:"form",message:"Approve?",serverName:"computer-use",requestedSchema:{type:"object",properties:{choice:{type:"string",enum:["allow","deny"]}},required:["choice"]}}});}
+   if(mode==="elicit"){pendingTool=m.id; return send({id:"elicitation-1",method:"mcpServer/elicitation/request",params:{mode:"form",message:"Choose access",serverName:"computer-use",requestedSchema:{type:"object",properties:{choice:{type:"string",enum:["allow","deny"]}},required:["choice"]},_meta:{source:"official-test"}}});}
    if(mode==="late-model-event"){send({id:m.id,result:{content:[{type:"text",text:"direct-ok"}],isError:false}});return send({method:"turn/started",params:{late:true}});}
    return send({id:m.id,result:{content:[{type:"text",text:"direct-ok"}],isError:false}});
  }
- if(m.id==="approval-1"&&m.result){return send({id:pendingTool,result:{content:[{type:"text",text:"approval:"+m.result.action}],isError:false}});}
+ if(m.id==="elicitation-1"&&m.result){return send({id:pendingTool,result:{content:[{type:"text",text:"elicitation:"+JSON.stringify(m.result)}],isError:false}});}
 });
 `, { mode: 0o700 });
 	return { script, log };
@@ -95,20 +95,77 @@ test("direct broker rejects upstream schema drift before tool dispatch", async (
 	} finally { await rm(root, { recursive: true, force: true }); }
 });
 
-test("no-permissions advertises no approval UI and never accepts an unexpected elicitation", async () => {
+test("direct broker forwards official elicitations and returns the invoking client's exact response", async () => {
 	const root = await mkdtemp(path.join(os.tmpdir(), "direct-broker-elicit-test."));
 	try {
-		const brokerSource = await readFile("src/direct-broker.ts", "utf8");
-		assert.doesNotMatch(brokerSource, /onElicitation|action:\s*["']accept["']/);
 		const { script, log } = await makeFake(root);
-		const declined = await callOfficialDirectTool("list_apps", {}, options(script, "elicit"));
-		assert.equal(declined.content[0].text, "approval:decline");
-		assert.equal(declined.approvalRequests, 1);
+		let observed: unknown;
+		const result = await callOfficialDirectTool("list_apps", {}, {
+			...options(script, "elicit"),
+			supportsOpenAiFormElicitation: true,
+			onElicitation: (request) => {
+				observed = request;
+				return { action: "accept", content: { choice: "allow" }, _meta: { client: "test" } };
+			},
+		});
+		assert.deepEqual(observed, {
+			mode: "form",
+			message: "Choose access",
+			serverName: "computer-use",
+			requestedSchema: { type: "object", properties: { choice: { type: "string", enum: ["allow", "deny"] } }, required: ["choice"] },
+			_meta: { source: "official-test" },
+		});
+		assert.equal(result.content[0].text, 'elicitation:{"action":"accept","content":{"choice":"allow"},"_meta":{"client":"test"}}');
+		assert.equal(result.elicitationRequests, 1);
 		const records = (await readFile(log, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
-		assert.deepEqual(records.find((item) => item.method === "initialize")?.params?.capabilities, { mcpServerOpenaiFormElicitation: false });
-		assert.deepEqual(records.find((item) => item.id === "approval-1" && item.result)?.result, { action: "decline" });
-		assert.equal(records.some((item) => item.id === "approval-1" && item.result?.action === "accept"), false);
+		assert.deepEqual(records.find((item) => item.method === "initialize")?.params?.capabilities, { mcpServerOpenaiFormElicitation: true });
+		assert.deepEqual(records.find((item) => item.id === "elicitation-1" && item.result)?.result, {
+			action: "accept", content: { choice: "allow" }, _meta: { client: "test" },
+		});
 	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("headless direct broker cancels rather than fabricating a decline", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "direct-broker-headless-elicit-test."));
+	try {
+		const { script, log } = await makeFake(root);
+		const result = await callOfficialDirectTool("list_apps", {}, options(script, "elicit"));
+		assert.equal(result.content[0].text, 'elicitation:{"action":"cancel"}');
+		const records = (await readFile(log, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+		assert.deepEqual(records.find((item) => item.id === "elicitation-1" && item.result)?.result, { action: "cancel" });
+		assert.equal(records.some((item) => item.id === "elicitation-1" && item.result?.action === "decline"), false);
+	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("cancellation while an elicitation UI is pending does not write to a closed broker", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "direct-broker-pending-elicit-test."));
+	let release!: () => void;
+	let entered!: () => void;
+	const waitForRelease = new Promise<void>((resolve) => { release = resolve; });
+	const elicitationEntered = new Promise<void>((resolve) => { entered = resolve; });
+	try {
+		const { script, log } = await makeFake(root);
+		const controller = new AbortController();
+		const call = callOfficialDirectTool("list_apps", {}, {
+			...options(script, "elicit"),
+			signal: controller.signal,
+			onElicitation: async () => {
+				entered();
+				await waitForRelease;
+				return { action: "accept", content: { choice: "allow" } };
+			},
+		});
+		await elicitationEntered;
+		controller.abort();
+		await assert.rejects(call, /cancelled/);
+		release();
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		const records = (await readFile(log, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+		assert.equal(records.some((item) => item.id === "elicitation-1" && item.result), false);
+	} finally {
+		release?.();
+		await rm(root, { recursive: true, force: true });
+	}
 });
 
 test("direct broker fails closed on any model-turn notification, including during teardown", async () => {

--- a/test/direct-service.test.ts
+++ b/test/direct-service.test.ts
@@ -13,7 +13,7 @@ function brokerResult(content = "ok", isError = false): DirectBrokerResult {
 		brokerVersion: "test-app-server",
 		clientBuild: "test-client",
 		durationMs: 10,
-		approvalRequests: 0,
+		elicitationRequests: 0,
 		modelTurnsStarted: 0,
 		ephemeralThread: true,
 		brokerCleanupVerified: true,
@@ -50,6 +50,23 @@ test("no-permissions directly permits read methods and canonicalizes app identit
 		]);
 		assert.equal(state.details.modelTurnsStarted, 0);
 		assert.equal(state.details.ephemeralRuntimeContext, true);
+	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("direct service passes client elicitation handling through to the signed broker", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "direct-service-elicit-test."));
+	try {
+		const onElicitation = async () => ({ action: "accept" as const, content: { choice: "allow" } });
+		let observedOptions: unknown;
+		const testDeps = deps(root, async (_method, _args, options) => {
+			observedOptions = options;
+			return brokerResult("state");
+		});
+		testDeps.onElicitation = onElicitation;
+		testDeps.supportsOpenAiFormElicitation = true;
+		await executeDirectTool({ method: "list_apps", arguments: {} }, testDeps);
+		assert.equal((observedOptions as any).onElicitation, onElicitation);
+		assert.equal((observedOptions as any).supportsOpenAiFormElicitation, true);
 	} finally { await rm(root, { recursive: true, force: true }); }
 });
 
@@ -149,7 +166,7 @@ test("broker failures preserve content-safe architecture evidence in audit", asy
 						directCalls: 1,
 						modelTurnsStarted: 1,
 						ephemeralThread: true,
-						approvalRequests: 1,
+						elicitationRequests: 1,
 						brokerVersion: "test-app-server",
 						clientBuild: "test-client",
 					});
@@ -162,7 +179,7 @@ test("broker failures preserve content-safe architecture evidence in audit", asy
 		assert.equal(audit.directCalls, 1);
 		assert.equal(audit.modelTurnsStarted, 1);
 		assert.equal(audit.ephemeralThread, true);
-		assert.equal(audit.approvalRequests, 1);
+		assert.equal(audit.elicitationRequests, 1);
 		assert.equal(audit.brokerCleanupVerified, true);
 	} finally { await rm(root, { recursive: true, force: true }); }
 });

--- a/test/mcp-elicitation.test.ts
+++ b/test/mcp-elicitation.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { forwardOfficialElicitationToMcpClient } from "../src/mcp-elicitation.ts";
+
+test("generic MCP forwards standard official form elicitations and returns the client response", async () => {
+	let observedParams: unknown;
+	let observedOptions: unknown;
+	const controller = new AbortController();
+	const response = await forwardOfficialElicitationToMcpClient({
+		async elicitInput(params, options) {
+			observedParams = params;
+			observedOptions = options;
+			return { action: "accept", content: { choice: "allow" }, _meta: { client: "test" } };
+		},
+	}, {
+		mode: "form",
+		message: "Choose access",
+		requestedSchema: {
+			type: "object",
+			properties: { choice: { type: "string", enum: ["allow", "deny"] } },
+			required: ["choice"],
+		},
+		_meta: { source: "official-test" },
+	}, controller.signal);
+	assert.deepEqual(observedParams, {
+		mode: "form",
+		message: "Choose access",
+		requestedSchema: {
+			type: "object",
+			properties: { choice: { type: "string", enum: ["allow", "deny"] } },
+			required: ["choice"],
+		},
+		_meta: { source: "official-test" },
+	});
+	assert.equal((observedOptions as any).signal, controller.signal);
+	assert.deepEqual(response, { action: "accept", content: { choice: "allow" }, _meta: { client: "test" } });
+});
+
+test("generic MCP elicitation crosses a real SDK client/server transport", async () => {
+	const server = new Server({ name: "test-server", version: "1" }, { capabilities: {} });
+	const client = new Client({ name: "test-client", version: "1" }, { capabilities: { elicitation: { form: {} } } });
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	let observed: unknown;
+	client.setRequestHandler(ElicitRequestSchema, async (request) => {
+		observed = request.params;
+		return { action: "accept", content: { name: "Thomas" } };
+	});
+	try {
+		await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+		const response = await forwardOfficialElicitationToMcpClient(server, {
+			mode: "form",
+			message: "Your name",
+			requestedSchema: { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+		});
+		assert.deepEqual(observed, {
+			mode: "form",
+			message: "Your name",
+			requestedSchema: { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+		});
+		assert.deepEqual(response, { action: "accept", content: { name: "Thomas" } });
+	} finally {
+		await client.close().catch(() => undefined);
+		await server.close().catch(() => undefined);
+	}
+});
+
+test("generic MCP forwards URL elicitations without converting them into wrapper prompts", async () => {
+	let observed: unknown;
+	const response = await forwardOfficialElicitationToMcpClient({
+		async elicitInput(params) {
+			observed = params;
+			return { action: "decline" };
+		},
+	}, {
+		mode: "url",
+		message: "Complete setup",
+		elicitationId: "setup-1",
+		url: "https://example.test/setup",
+	});
+	assert.deepEqual(observed, {
+		mode: "url",
+		message: "Complete setup",
+		elicitationId: "setup-1",
+		url: "https://example.test/setup",
+	});
+	assert.deepEqual(response, { action: "decline" });
+});
+
+test("unsupported or unavailable MCP elicitation support cancels and never fabricates a decline", async () => {
+	const unavailable = await forwardOfficialElicitationToMcpClient({
+		async elicitInput() { throw new Error("client does not support elicitation"); },
+	}, { mode: "form", message: "Input", requestedSchema: { type: "object", properties: {} } });
+	assert.deepEqual(unavailable, { action: "cancel" });
+
+	let called = false;
+	const proprietary = await forwardOfficialElicitationToMcpClient({
+		async elicitInput() { called = true; return { action: "accept" }; },
+	}, { mode: "openai/form", message: "Input", requestedSchema: { type: "object", properties: {} } });
+	assert.equal(called, false);
+	assert.deepEqual(proprietary, { action: "cancel" });
+});

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -35,7 +35,8 @@ test("stdio MCP advertises one unrestricted no-permissions interface with all te
 		assert.equal(status.isError, undefined);
 		const details = status.structuredContent as Record<string, unknown>;
 		assert.equal(details.permissionMode, "no-permissions");
-		assert.equal(details.approvalPrompts, false);
+		assert.equal(details.wrapperPermissionPrompts, false);
+		assert.equal(details.officialElicitationHandling, "forwarded-when-client-supported");
 		assert.equal(details.wrapperAuthorization, "unrestricted");
 		assert.deepEqual(details.availableMethods, OFFICIAL_METHODS);
 		assert.equal(details.brokerVerified, true);

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -16,10 +16,7 @@ test("Pi adapter registers all ten tools through one no-permissions path with no
 		"computer-use-mode",
 		"saveConfig",
 		"loadConfig",
-		"onElicitation",
-		"handleElicitation",
 		"ctx.ui.confirm",
-		"ctx.ui.select",
 		"ctx.ui.input",
 		"full-permissions",
 		"safe mode",
@@ -37,7 +34,89 @@ test("Pi adapter registers all ten tools through one no-permissions path with no
 	}
 	assert.match(source, /OFFICIAL_TOOL_METADATA\[method\]\.description/);
 	assert.match(source, /executeDirectTool/);
+	assert.match(source, /onElicitation: \(request\) => handleOfficialElicitation/);
+	assert.match(source, /supportsOpenAiFormElicitation: true/);
 	assert.match(source, /Call computer_use_get_app_state once per assistant turn before interacting with an app/);
+});
+
+test("Pi surfaces an official form elicitation and returns the user's structured response", async () => {
+	const { handleOfficialElicitation } = await import("../integrations/pi/index.ts");
+	const calls: Array<{ kind: string; value: unknown }> = [];
+	const ctx = {
+		hasUI: true,
+		ui: {
+			async select(title: string, options: string[]) { calls.push({ kind: "select", value: { title, options } }); return "Respond"; },
+			async editor(title: string, prefill?: string) { calls.push({ kind: "editor", value: { title, prefill } }); return '{"choice":"allow"}'; },
+			notify(message: string) { calls.push({ kind: "notify", value: message }); },
+		},
+	};
+	const response = await handleOfficialElicitation({
+		mode: "form",
+		message: "Choose access",
+		requestedSchema: { type: "object", properties: { choice: { type: "string", enum: ["allow", "deny"] } } },
+	}, ctx, async () => { throw new Error("must not open a URL for form elicitation"); });
+	assert.deepEqual(response, { action: "accept", content: { choice: "allow" } });
+	assert.equal((calls[0].value as any).title, "Choose access");
+	assert.match((calls[1].value as any).title, /Schema:/);
+	assert.match((calls[1].value as any).prefill, /"choice": "allow"/);
+});
+
+test("Pi preserves opaque OpenAI-form schemas and JSON responses", async () => {
+	const { handleOfficialElicitation } = await import("../integrations/pi/index.ts");
+	let editorTitle = "";
+	const response = await handleOfficialElicitation({
+		mode: "openai/form", message: "Official custom form", requestedSchema: ["opaque", { widget: "custom" }],
+	}, {
+		hasUI: true,
+		ui: {
+			async select() { return "Respond"; },
+			async editor(title: string) { editorTitle = title; return '"completed"'; },
+			notify() {},
+		},
+	}, async () => false);
+	assert.match(editorTitle, /\["opaque",\{"widget":"custom"\}\]/);
+	assert.deepEqual(response, { action: "accept", content: "completed" });
+});
+
+test("Pi URL elicitation opens only after user choice and returns that acceptance", async () => {
+	const { handleOfficialElicitation } = await import("../integrations/pi/index.ts");
+	const choices = ["Open URL"];
+	const opened: string[] = [];
+	const response = await handleOfficialElicitation({
+		mode: "url", message: "Complete setup", url: "https://example.test/setup", elicitationId: "setup-1",
+	}, {
+		hasUI: true,
+		ui: {
+			async select() { return choices.shift(); },
+			async editor() { return undefined; },
+			notify() {},
+		},
+	}, async (url) => { opened.push(url); return true; });
+	assert.deepEqual(opened, ["https://example.test/setup"]);
+	assert.deepEqual(response, { action: "accept" });
+
+	const declined = await handleOfficialElicitation({
+		mode: "url", message: "Complete setup", url: "https://example.test/setup", elicitationId: "setup-2",
+	}, {
+		hasUI: true,
+		ui: { async select() { return "Decline"; }, async editor() { return undefined; }, notify() {} },
+	}, async () => { throw new Error("declined URL must not open"); });
+	assert.deepEqual(declined, { action: "decline" });
+});
+
+test("Pi preserves explicit decline and uses cancel when no UI is available", async () => {
+	const { handleOfficialElicitation } = await import("../integrations/pi/index.ts");
+	const request = { mode: "form", message: "Choose", requestedSchema: { type: "object", properties: {} } };
+	const declined = await handleOfficialElicitation(request, {
+		hasUI: true,
+		ui: { async select() { return "Decline"; }, async editor() { return undefined; }, notify() {} },
+	}, async () => true);
+	assert.deepEqual(declined, { action: "decline" });
+	const headless = await handleOfficialElicitation(request, {
+		hasUI: false,
+		ui: { async select() { throw new Error("unreachable"); }, async editor() { throw new Error("unreachable"); }, notify() {} },
+	}, async () => true);
+	assert.deepEqual(headless, { action: "cancel" });
 });
 
 test("Pi runtime registration exposes the exact official contract for all ten tools", async () => {


### PR DESCRIPTION
## Summary
- forward signed app-server `mcpServer/elicitation/request` messages instead of silently declining them
- render form, OpenAI-form, and URL elicitations in Pi; forward standard form/URL elicitations through MCP `elicitation/create`
- preserve user/client `accept`, `decline`, `cancel`, content, and metadata responses; use `cancel` for headless or unsupported clients
- distinguish wrapper permission prompts from authoritative official-service elicitations in status, audit metadata, and documentation

## Verification
- `npm run prepublishOnly` — 58/58 tests passed
- `npm pack --dry-run` — 39 intended files
- `npm audit --omit=dev` — 0 vulnerabilities
- fake signed-app-server round trip covers exact request/response forwarding and pending-UI cancellation
- real MCP SDK in-memory client/server transport covers standard elicitation forwarding
