### PR TITLE
feat: progressively disclose Pi interaction tools

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,6 +133,12 @@ App-server is created with `approvalPolicy: "never"` and `sandbox: "danger-full-
 
 The broker still handles any `mcpServer/elicitation/request` that app-server emits. Pi advertises OpenAI-form support and renders emitted form, OpenAI-form, and URL requests. Generic stdio MCP forwards supported standard modes as `elicitation/create`. The response path preserves `accept`, `decline`, `cancel`, structured content, and response metadata; no callback or compatible UI yields `cancel`, never an invented decision.
 
+## Pi tool disclosure boundary
+
+The Pi extension registers all ten official definitions. On `session_start` it preserves active tools owned by Pi and other extensions, keeps `computer_use_list_apps` and `computer_use_get_app_state` active, and removes only the eight Computer Use interaction definitions from the initial active set. After a successful `get_app_state` result, it additively activates those eight definitions without removing any currently active tool.
+
+This is context disclosure, not a wrapper permission gate. The schemas, execution path, and no-permissions policy do not change. Loader and interaction definitions remain registered throughout the session. The interaction definitions omit `promptSnippet` and `promptGuidelines`, allowing Pi 0.80.7's native deferred-loading representation to add schemas at the tool-result position without changing the system-prompt prefix. Providers without native support use Pi's next-request fallback.
+
 ## Output boundary
 
 Only official `text` and `image` MCP blocks are accepted. They are returned to the invoking client because app state and screenshots are the requested capability. They are never copied to audit, logs, temp files, or structured metadata. Text is truncated in memory at Pi's standard 50KB/2000-line bound; the full text is not persisted.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration and rollback
 
-Version 0.2.0 is a breaking architecture change. It replaces the aggregate nested-model tool with ten direct typed tools. The direct implementation passed immutable exact-head review and rollback-safe activation before release. Follow this guide to move from version 0.1.0.
+Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 keeps that exact ten-tool contract and adds Pi 0.80.7 progressive disclosure. Use the relevant section below.
 
 ## What changes
 
@@ -63,11 +63,25 @@ Do not copy old safe/full configuration into the new state root. No-permissions 
 
 Version 0.2.0 does not support targeted local Computer Use while the Mac is locked. OpenAI reserves locked use for active trusted turns started from a connected device. See the [locked-screen limitation](README.md#locked-screen-limitation).
 
+## Upgrade from version 0.2.0 to 0.3.0
+
+The MCP contract and signed execution path do not change. The native Pi extension now registers all ten definitions but initially activates only `computer_use_list_apps` and `computer_use_get_app_state`.
+
+1. Upgrade Pi to version 0.80.7 or newer.
+2. Back up `~/.pi/agent/settings.json` and the installed 0.2 package directory.
+3. Verify that npm resolves `codex-computer-use-mcp@0.3.0` exactly, then install that exact package.
+4. Start a fresh Pi process.
+5. Verify that the two inspection tools are initially active and the eight interaction tools remain registered but inactive.
+6. Call `computer_use_get_app_state` against a benign app while the Mac is unlocked. A successful result should add all eight interaction tools without removing any active tool.
+7. Exercise a benign interaction, inspect the private content-safe audit, and verify process cleanup.
+
+The change is context disclosure, not a permission mode. Codex Full access, emitted elicitation forwarding, schemas, and the no-permissions policy remain unchanged.
+
 ## Rollback
 
 1. Stop the current Pi process.
 2. Confirm no direct app-server/client/focus/lock process remains.
-3. Remove or disable the 0.2 package registration.
+3. Remove or disable the current package registration.
 4. Restore the backed-up 0.1 package/config registration byte-for-byte.
 5. Start a fresh Pi process.
 6. Verify the old status command and installed hash.
@@ -77,4 +91,4 @@ Direct state can be removed only after rollback evidence is captured and no proc
 
 ## Generic MCP gateway
 
-If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.2.0` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.
+If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.0` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.

--- a/PROOF.md
+++ b/PROOF.md
@@ -74,6 +74,8 @@ Current branch tests cover:
 - signed app-server elicitation forwarding, exact user responses, headless cancellation, and cancellation while a UI callback is pending;
 - standard form/URL forwarding across a real MCP SDK client/server transport;
 - Pi source registration for every direct capability with no nested planner, permission command, or wrapper-generated approval UI;
+- Pi session-start disclosure of only the two inspection definitions while preserving unrelated active tools;
+- purely additive activation of all eight interaction definitions after successful `get_app_state`, with no lazy-tool prompt metadata;
 - Pi form, opaque OpenAI-form, URL, decline, and headless-cancel elicitation handling.
 
 ## Official Full access approval probe
@@ -114,6 +116,19 @@ Evidence:
 - TextEdit was stopped and the disposable document removed after verification.
 
 Earlier exploratory attempts exposed and fixed two acceptance-quality issues rather than being counted as proof: common `CMD+A` needed normalization to the official `Meta_L+a` key form, and TextEdit state restoration had to be reset before a fresh run. The final evidence above is from the corrected direct path.
+
+## Pi 0.80.7 progressive-disclosure measurement
+
+A fresh Pi 0.80.7 process loaded only the source Computer Use extension plus a read-only observer. All ten definitions were registered. The initial active Computer Use set was exactly:
+
+- `computer_use_list_apps`
+- `computer_use_get_app_state`
+
+Serializing names, descriptions, schemas, and prompt guidelines measured 6,063 bytes for all ten definitions and 1,231 bytes for the initial two: 4,832 bytes removed from the initial request, a 79.7% reduction for this tool family.
+
+A second fresh process exercised the exported activation path from inside a tool execution. Pi's tool result recorded the exact eight interaction names in `addedToolNames`; the before/after active sets retained both inspection tools and removed zero tools. The lazily activated definitions had no `promptSnippet` or `promptGuidelines`.
+
+With `openai-codex/gpt-5.6-sol`, the first request reported 5,723 uncached input tokens. The immediately following request after additive activation reported 1,008 uncached input tokens and 5,632 cache-read tokens. This is live provider evidence that the initial prefix remained reusable while Pi inserted the eight definitions at the tool-result load point. The activation probe used the same `activateInteractionTools` function called after a successful production `get_app_state`; automated tests bind that successful-result branch and exact additive set.
 
 ## Review and release status
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Computer Use MCP
 
-Version 0.2.0 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
+Version 0.3.0 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
 
 The primary path has:
 
@@ -32,6 +32,8 @@ Pi registers namespaced tools to avoid collisions with Pi's built-ins. The MCP s
 | `computer_use_type_text` | `type_text` | yes | Type literal text |
 
 The MCP façade preserves the official signed helper's tool descriptions, input schemas, and annotations exactly. The Pi façade preserves its descriptions and input schemas; Pi's tool API does not expose MCP annotations. In particular, all ten MCP methods have `destructiveHint: false`; the wrapper does not conflate changing UI state with destructive behavior or add argument restrictions absent from the official schemas.
+
+Pi 0.80.7 and newer registers all ten definitions but initially activates only `computer_use_list_apps` and `computer_use_get_app_state`. A successful `get_app_state` call additively activates the eight interaction definitions for the following model request. Other active Pi and extension tools remain active. The lazily activated tools omit `promptSnippet` and `promptGuidelines`, allowing Pi's native deferred-loading path to preserve the stable system-prompt prefix.
 
 As the official contract specifies, Pi—not a nested planner—calls `computer_use_get_app_state` once per assistant turn before interacting with an app, then chooses and executes actions itself.
 
@@ -65,6 +67,7 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for source links and the full restricti
 
 - macOS
 - Node.js 22 or newer
+- Pi 0.80.7 or newer for native progressive tool disclosure
 - official ChatGPT macOS app at `/Applications/ChatGPT.app`
 - official Computer Use component installed
 
@@ -72,16 +75,16 @@ The direct bridge starts app-server with a new private `CODEX_HOME` containing n
 
 ### Locked-screen limitation
 
-Version 0.2.0 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
+Version 0.3.0 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
 
-OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.2.0.
+OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.0.
 
 ## Pi integration
 
 Install the exact release from npm:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.2.0
+pi install npm:codex-computer-use-mcp@0.3.0
 ```
 
 To evaluate a source checkout instead:
@@ -98,7 +101,7 @@ Command:
 /computer-use-status
 ```
 
-The native Pi adapter is the primary product path. It always registers all ten typed tools directly and exposes no mode-changing command or wrapper-generated approval UI. Official app-access approval elicitations are resolved by Codex Full access before they reach Pi. Any elicitation that app-server does emit is shown through Pi's UI, and only the user's choice is returned to the service.
+The native Pi adapter is the primary product path. It registers all ten typed tools directly, starts each session with the two inspection tools active, and additively activates the eight interaction tools after successful app inspection. It exposes no mode-changing command or wrapper-generated approval UI. Official app-access approval elicitations are resolved by Codex Full access before they reach Pi. Any elicitation that app-server does emit is shown through Pi's UI, and only the user's choice is returned to the service.
 
 ## MCP server
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,6 @@ Computer Use returns the official app-state text and screenshots to the invoking
 
 ## Supported versions
 
-Only the latest approved release is supported. Version 0.2.0 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
+Only the latest approved release is supported. Version 0.3.0 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
 
 App-server is experimental and bundle paths or schemas can change. Drift fails closed until reviewed.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,6 +1,6 @@
 # Pi integration
 
-The native Pi adapter is the primary 0.2 path. It registers ten namespaced typed tools so Pi itself chooses each official Computer Use method and argument.
+The native Pi adapter is the primary 0.3 path. It registers ten namespaced typed tools so Pi itself chooses each official Computer Use method and argument. Pi 0.80.7 or newer exposes them progressively without changing the ten-tool contract.
 
 ## Source checkout acceptance
 
@@ -13,18 +13,23 @@ CODEX_COMPUTER_USE_HOME="$(mktemp -d)" \
 
 `-ne` prevents an installed 0.1 adapter from loading at the same time. This source workflow does not install or switch live Pi configuration.
 
-For normal installation, use the exact version 0.2.0 npm package:
+For normal installation, use the exact version 0.3.0 npm package:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.2.0
+pi install npm:codex-computer-use-mcp@0.3.0
 ```
 
 Use the source workflow only when you need to test an exact reviewed commit. Follow the rollback procedure in `MIGRATION.md` when replacing version 0.1.
 
 ## Registered surface
 
+Initially active:
+
 - `computer_use_list_apps`
 - `computer_use_get_app_state`
+
+Registered and activated after a successful `get_app_state` call:
+
 - `computer_use_click`
 - `computer_use_perform_secondary_action`
 - `computer_use_set_value`
@@ -33,13 +38,18 @@ Use the source workflow only when you need to test an exact reviewed commit. Fol
 - `computer_use_drag`
 - `computer_use_press_key`
 - `computer_use_type_text`
+
+Command:
+
 - `/computer-use-status`
 
-No-permissions is the only policy: all ten tools are available with no wrapper permission prompts, mode selector, or app/intent/action gate. The signed host runs with Codex Full access (`approvalPolicy: "never"`, `sandbox: "danger-full-access"`), so normal empty-schema Computer Use app approvals are accepted by Codex before they reach Pi. Pi renders any form, OpenAI-form, or URL elicitation app-server does emit. The user's `accept`, `decline`, or `cancel` response is returned unchanged; the adapter never fabricates one.
+The session-start narrowing preserves every active tool owned by Pi or another extension. Activation after inspection is purely additive: both inspection tools remain active, and the adapter does not remove or replace any tool in that call. The lazily activated tools rely on their official descriptions and omit `promptSnippet` and `promptGuidelines`, so native deferred schema loading does not rebuild the system prompt. Supported Anthropic and OpenAI models receive the definitions at the inspection result; other models receive Pi's normal active-tool fallback on the next request.
+
+No-permissions is the only policy: all ten tools are registered and available through this lifecycle with no wrapper permission prompts, mode selector, or app/intent/action gate. The signed host runs with Codex Full access (`approvalPolicy: "never"`, `sandbox: "danger-full-access"`), so normal empty-schema Computer Use app approvals are accepted by Codex before they reach Pi. Pi renders any form, OpenAI-form, or URL elicitation app-server does emit. The user's `accept`, `decline`, or `cancel` response is returned unchanged; the adapter never fabricates one.
 
 ## Generic MCP gateway
 
-Merge `mcp.json.example` only for the exact 0.2.0 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
+Merge `mcp.json.example` only for the exact 0.3.0 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
 
 For a source checkout:
 

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -66,6 +66,33 @@ function titleFor(method: DirectMethod): string {
   return method.split("_").map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`).join(" ");
 }
 
+const INSPECTION_METHODS = new Set<DirectMethod>(["list_apps", "get_app_state"]);
+export const INSPECTION_TOOL_NAMES = [
+  "computer_use_list_apps",
+  "computer_use_get_app_state",
+] as const;
+export const INTERACTION_TOOL_NAMES = [
+  "computer_use_click",
+  "computer_use_perform_secondary_action",
+  "computer_use_set_value",
+  "computer_use_select_text",
+  "computer_use_scroll",
+  "computer_use_drag",
+  "computer_use_press_key",
+  "computer_use_type_text",
+] as const;
+
+export function setInitialComputerUseTools(pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools">): void {
+  const interactionTools = new Set<string>(INTERACTION_TOOL_NAMES);
+  const preserved = pi.getActiveTools().filter((name) => !interactionTools.has(name));
+  pi.setActiveTools([...new Set([...preserved, ...INSPECTION_TOOL_NAMES])]);
+}
+
+export function activateInteractionTools(pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools">): void {
+  const active = pi.getActiveTools();
+  pi.setActiveTools([...new Set([...active, ...INTERACTION_TOOL_NAMES])]);
+}
+
 function toPiContent(content: Array<Record<string, unknown>>): Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> {
   const result: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> = [];
   for (const block of content) {
@@ -173,15 +200,18 @@ export default function directComputerUse(pi: ExtensionAPI) {
   const methods = Object.keys(ToolParameters) as DirectMethod[];
   for (const method of methods) {
     const piName = `computer_use_${method}`;
-    pi.registerTool({
-      name: piName,
-      label: titleFor(method),
-      description: toolDescription(method),
+    const inspectionPromptMetadata = INSPECTION_METHODS.has(method) ? {
       promptSnippet: `${titleFor(method)} through the official signed macOS Computer Use service`,
       promptGuidelines: [
         `${piName} is a direct typed tool: choose its arguments yourself; it does not invoke a nested planner or model.`,
         `Call computer_use_get_app_state once per assistant turn before interacting with an app.`,
       ],
+    } : {};
+    pi.registerTool({
+      name: piName,
+      label: titleFor(method),
+      description: toolDescription(method),
+      ...inspectionPromptMetadata,
       parameters: ToolParameters[method] as any,
       async execute(_toolCallId, params, signal, onUpdate, ctx) {
         const response = await executeDirectTool(
@@ -202,6 +232,7 @@ export default function directComputerUse(pi: ExtensionAPI) {
           },
         );
         if (response.isError) throw new Error(errorText(response.content));
+        if (method === "get_app_state") activateInteractionTools(pi);
         return { content: toPiContent(response.content), details: response.details };
       },
       renderCall(args, theme) {
@@ -211,4 +242,6 @@ export default function directComputerUse(pi: ExtensionAPI) {
       },
     });
   }
+
+  pi.on("session_start", () => setInitialComputerUseTools(pi));
 }

--- a/integrations/pi/mcp.json.example
+++ b/integrations/pi/mcp.json.example
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "codex-computer-use-mcp@0.2.0"
+        "codex-computer-use-mcp@0.3.0"
       ],
       "lifecycle": "lazy",
       "requestTimeoutMs": 180000,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-computer-use-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "os": [
         "darwin"
@@ -21,9 +21,9 @@
         "codex-computer-use-mcp": "dist/mcp-server.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.80.6",
-        "@earendil-works/pi-coding-agent": "0.80.6",
-        "@earendil-works/pi-tui": "0.80.6",
+        "@earendil-works/pi-ai": "0.80.7",
+        "@earendil-works/pi-coding-agent": "0.80.7",
+        "@earendil-works/pi-tui": "0.80.7",
         "typebox": "1.1.38"
       },
       "engines": {
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
+      "integrity": "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -567,16 +567,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
+      "integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-tui": "^0.80.7",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1066,13 +1066,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
-      "integrity": "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.7",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1082,9 +1081,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1108,9 +1106,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2543,9 +2540,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Expose the official macOS Computer Use tools directly to Pi and MCP clients without a nested model.",
   "author": "Thomas Mustier",
   "license": "MIT",
@@ -74,9 +74,9 @@
     }
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.80.6",
-    "@earendil-works/pi-coding-agent": "0.80.6",
-    "@earendil-works/pi-tui": "0.80.6",
+    "@earendil-works/pi-ai": "0.80.7",
+    "@earendil-works/pi-coding-agent": "0.80.7",
+    "@earendil-works/pi-tui": "0.80.7",
     "typebox": "1.1.38"
   },
   "engines": {

--- a/src/direct-broker.ts
+++ b/src/direct-broker.ts
@@ -606,7 +606,7 @@ export async function callOfficialDirectTool(
 		await request(
 			"initialize",
 			{
-				clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.2.0" },
+				clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.0" },
 				capabilities: { mcpServerOpenaiFormElicitation: options.supportsOpenAiFormElicitation === true && options.onElicitation !== undefined },
 			},
 			15_000,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,7 @@ import {
 	OFFICIAL_TOOL_METADATA,
 } from "./tools.ts";
 
-const version = "0.2.0";
+const version = "0.3.0";
 
 async function handleCli(): Promise<boolean> {
 	const args = process.argv.slice(2);

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA } from "../src/tools.ts";
 
-test("Pi adapter registers all ten tools through one no-permissions path with no prompt or mode route", async () => {
+test("Pi adapter registers all ten tools through one no-permissions path with progressive disclosure", async () => {
 	const source = await readFile("integrations/pi/index.ts", "utf8");
 	assert.match(source, /const piName = `computer_use_\$\{method\}`/);
 	for (const method of OFFICIAL_METHODS) assert.match(source, new RegExp(`\\b${method}: Type\\.Object`));
@@ -37,6 +37,8 @@ test("Pi adapter registers all ten tools through one no-permissions path with no
 	assert.match(source, /onElicitation: \(request\) => handleOfficialElicitation/);
 	assert.match(source, /supportsOpenAiFormElicitation: true/);
 	assert.match(source, /Call computer_use_get_app_state once per assistant turn before interacting with an app/);
+	assert.match(source, /if \(method === "get_app_state"\) activateInteractionTools\(pi\)/);
+	assert.match(source, /pi\.on\("session_start", \(\) => setInitialComputerUseTools\(pi\)\)/);
 });
 
 test("Pi surfaces an official form elicitation and returns the user's structured response", async () => {
@@ -120,12 +122,27 @@ test("Pi preserves explicit decline and uses cancel when no UI is available", as
 });
 
 test("Pi runtime registration exposes the exact official contract for all ten tools", async () => {
-	const { default: adapter } = await import("../integrations/pi/index.ts");
-	const tools: Array<{ name: string; description: string; parameters: unknown; promptGuidelines: string[] }> = [];
+	const {
+		default: adapter,
+		INSPECTION_TOOL_NAMES,
+		INTERACTION_TOOL_NAMES,
+	} = await import("../integrations/pi/index.ts");
+	const tools: Array<{
+		name: string;
+		description: string;
+		parameters: unknown;
+		promptSnippet?: string;
+		promptGuidelines?: string[];
+	}> = [];
 	const commands: string[] = [];
+	const handlers = new Map<string, () => void>();
+	const active = new Set(["read", ...OFFICIAL_METHODS.map((method) => `computer_use_${method}`)]);
 	adapter({
-		registerTool(tool: { name: string; description: string; parameters: unknown; promptGuidelines: string[] }) { tools.push(tool); },
+		registerTool(tool: typeof tools[number]) { tools.push(tool); },
 		registerCommand(name: string) { commands.push(name); },
+		on(name: string, handler: () => void) { handlers.set(name, handler); },
+		getActiveTools() { return [...active]; },
+		setActiveTools(names: string[]) { active.clear(); for (const name of names) active.add(name); },
 	} as any);
 	assert.deepEqual(commands, ["computer-use-status"]);
 	assert.deepEqual(tools.map((tool) => tool.name).sort(), OFFICIAL_METHODS.map((method) => `computer_use_${method}`).sort());
@@ -133,5 +150,30 @@ test("Pi runtime registration exposes the exact official contract for all ten to
 		const tool = tools.find((item) => item.name === `computer_use_${method}`)!;
 		assert.equal(tool.description, OFFICIAL_TOOL_METADATA[method].description);
 		assert.deepEqual(tool.parameters, EXPECTED_OFFICIAL_INPUT_SCHEMAS[method]);
+		if (INSPECTION_TOOL_NAMES.includes(tool.name as any)) {
+			assert.ok(tool.promptSnippet);
+			assert.ok(tool.promptGuidelines?.length);
+		} else {
+			assert.equal(tool.promptSnippet, undefined);
+			assert.equal(tool.promptGuidelines, undefined);
+		}
 	}
+
+	handlers.get("session_start")!();
+	assert.ok(active.has("read"), "preserves tools owned by Pi and other extensions");
+	for (const name of INSPECTION_TOOL_NAMES) assert.ok(active.has(name));
+	for (const name of INTERACTION_TOOL_NAMES) assert.ok(!active.has(name));
+});
+
+test("Pi interaction activation is purely additive", async () => {
+	const { activateInteractionTools, INTERACTION_TOOL_NAMES } = await import("../integrations/pi/index.ts");
+	const before = ["read", "computer_use_list_apps", "computer_use_get_app_state", "another_extension_tool"];
+	let after: string[] = [];
+	activateInteractionTools({
+		getActiveTools: () => [...before],
+		setActiveTools: (names: string[]) => { after = names; },
+	} as any);
+	for (const name of before) assert.ok(after.includes(name), `preserves active tool ${name}`);
+	for (const name of INTERACTION_TOOL_NAMES) assert.ok(after.includes(name), `activates ${name}`);
+	assert.equal(new Set(after).size, after.length);
 });


### PR DESCRIPTION
## Summary

- register all ten official Computer Use tools but initially activate only `list_apps` and `get_app_state` in Pi
- additively activate the eight interaction tools after a successful app-state inspection
- omit prompt metadata from lazy tools so Pi 0.80.7 can preserve the stable prompt prefix
- bump the package to 0.3.0 and document migration, architecture, and measured cache behavior

## Evidence

- `npm run prepublishOnly` — 59/59 tests pass
- `npm audit --omit=dev` — zero vulnerabilities
- package dry run — 40 intended files, shrinkwrap and ADR present
- fresh Pi initial Computer Use definitions: 6,063 → 1,231 bytes (79.7% reduction)
- additive activation recorded all eight names and removed zero tools
- GPT-5.6 Sol follow-up: 5,632 cache-read tokens and 1,008 uncached input tokens
- read-only review: no blocking findings
