### PR TITLE
fix(system): parse macOS 27 lsappinfo bundleID format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+This changelog records user-visible changes from version 0.3.2 onwards.
+
+## Unreleased
+
+### Fixed
+
+- Support the macOS 27 `lsappinfo` `bundleID` output so frontmost-app detection can proceed to official Computer Use dispatch. [Brad Hallett](https://github.com/bradhallett) contributed this fix in [PR #6](https://github.com/tmustier/codex-computer-use-mcp/pull/6).
+
+### Documentation
+
+- Clarify that this package is a thin transport adapter and distinguish official transport requirements from retained legacy wrapper behavior in [PR #12](https://github.com/tmustier/codex-computer-use-mcp/pull/12).

--- a/src/system.ts
+++ b/src/system.ts
@@ -5,6 +5,20 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Parse the bundle identifier from `lsappinfo info -only bundleID <asn>` output.
+ *
+ * Upstream API assumption: LaunchServices changed the emitted key across macOS
+ * releases. macOS <= 26 prints `"CFBundleIdentifier"="com.example"`; macOS 27+
+ * (Darwin 27) prints `bundleID="com.example"` and drops `CFBundleIdentifier`.
+ * Accept both spellings so frontmost detection survives the rename; otherwise
+ * `frontmostBundleId()` returns `undefined` and every direct dispatch throws
+ * "Could not observe the frontmost app" before reaching the broker.
+ */
+export function parseLsappinfoBundleId(stdout: string): string | undefined {
+	return stdout.match(/(?:"CFBundleIdentifier"|bundleID)="([^"]+)"/)?.[1];
+}
+
 export function frontmostApplicationToken(): string | undefined {
 	const front = spawnSync("/usr/bin/lsappinfo", ["front"], { encoding: "utf8", timeout: 3000 });
 	const asn = (front.stdout ?? "").trim();
@@ -19,8 +33,7 @@ export function frontmostBundleId(): string | undefined {
 		timeout: 3000,
 	});
 	if (info.status !== 0) return undefined;
-	const match = (info.stdout ?? "").match(/"CFBundleIdentifier"="([^"]+)"/);
-	return match?.[1];
+	return parseLsappinfoBundleId(info.stdout ?? "");
 }
 
 export async function frontmostBundleIdAsync(): Promise<string | undefined> {
@@ -32,7 +45,7 @@ export async function frontmostBundleIdAsync(): Promise<string | undefined> {
 			encoding: "utf8",
 			timeout: 3000,
 		});
-		return info.stdout.match(/"CFBundleIdentifier"="([^"]+)"/)?.[1];
+		return parseLsappinfoBundleId(info.stdout);
 	} catch {
 		return undefined;
 	}
@@ -123,7 +136,7 @@ function bundleIdForAsn(asn: string, infoPath = "/usr/bin/lsappinfo"): string | 
 		timeout: 3000,
 	});
 	if (info.status !== 0) return undefined;
-	return (info.stdout ?? "").match(/"CFBundleIdentifier"="([^"]+)"/)?.[1];
+	return parseLsappinfoBundleId(info.stdout ?? "");
 }
 
 export async function watchTargetFrontmost(

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -7,6 +7,7 @@ import {
 	frontmostApplicationToken,
 	frontmostBundleId,
 	frontmostBundleIdAsync,
+	parseLsappinfoBundleId,
 	resolveAppIdentity,
 	resolveAppLeaseId,
 	watchTargetFrontmost,
@@ -17,6 +18,16 @@ test("async focus sampling matches the synchronous frontmost bundle", async () =
 	const asyncValue = await frontmostBundleIdAsync();
 	assert.ok(sync);
 	assert.ok(asyncValue);
+});
+
+test("lsappinfo bundle-id parser accepts macOS 27 bundleID and legacy CFBundleIdentifier keys", () => {
+	// macOS 27 (Darwin 27) dropped `CFBundleIdentifier` from `lsappinfo info -only bundleID`
+	// output and now emits `bundleID=`. Both spellings must parse, or frontmost detection
+	// returns undefined and every direct dispatch throws before reaching the broker.
+	assert.equal(parseLsappinfoBundleId(`[ NULL ]  ASN:0x0-0x39039: (in front) \n\tbundleID="com.docker.docker"\n`), "com.docker.docker");
+	assert.equal(parseLsappinfoBundleId(`"CFBundleIdentifier"="com.apple.finder"\n`), "com.apple.finder");
+	assert.equal(parseLsappinfoBundleId(""), undefined);
+	assert.equal(parseLsappinfoBundleId("no bundle key here"), undefined);
 });
 
 test("app identity preserves the official bundle ID while canonicalizing leases", () => {


### PR DESCRIPTION
## Problem

On macOS 27 (Darwin 27), `get_app_state` — and every interactive method that depends on it (`click`, `type_text`, `press_key`, `scroll`, `drag`, `set_value`, `select_text`, `perform_secondary_action`) — fails with:

```
Could not observe the frontmost app before direct dispatch
```

The audit log records `outcome=policy_violation`, `brokerVersion=null`, `directCalls=0` — **identical to a TCC-denial signature**, which made this look like a permissions problem. It is not.

## Root cause

LaunchServices changed the output of `lsappinfo info -only bundleID <asn>` across macOS releases:

| macOS | output |
|---|---|
| ≤ 26 | `"CFBundleIdentifier"="com.example"` (key quoted) |
| 27 (Darwin 27) | `bundleID="com.example"` (key unquoted; `CFBundleIdentifier` dropped) |

`system.ts` matched only the quoted form. On macOS 27 the regex never matches, so `frontmostBundleId()` / `frontmostBundleIdAsync()` / `bundleIdForAsn()` return `undefined`, and `executeDirectTool` throws before the broker is ever called (`directCalls: 0`). `lsappinfo` needs no TCC grant and was returning data the whole time — the code simply could not parse it.

This breaks every macOS 27 user of the plugin.

## Fix

Extract the shared parse into `parseLsappinfoBundleId` — one regex across the three call sites (the regex was triplicated, which is exactly why the bug existed in three places), plus a single test seam — and accept both spellings:

```ts
return stdout.match(/(?:"CFBundleIdentifier"|bundleID)="([^"]+)"/)?.[1];
```

The upstream `lsappinfo` format assumption is documented in the helper's JSDoc, per CONTRIBUTING ("Document fixed ChatGPT bundle paths and upstream schema/API assumptions").

## Regression test

`test/system.test.ts` parses both the legacy quoted form and the macOS 27 unquoted form, plus negative cases. It fails on any regex that handles only one spelling and passes on the form that accepts both. The existing focus-watcher tests route through `bundleIdForAsn` → the parser, so they cover the integration path as well (they regress if the parser is wrong).

## Verification (CONTRIBUTING chain)

```
npm ci           ✅
npm run check    ✅ tsc --noEmit clean
npm run check:pi ✅ clean
npm test         ✅ 60/60 pass
npm run build    ✅
```

**Real-app acceptance** (benign app, not a disposable harness): `get_app_state(Finder)` through the official signed `codex app-server` broker returns `outcome=ok`, `directCalls=1`, `brokerVersion=codex-cli 0.145.0-alpha.18`, with the accessibility tree and a JPEG screenshot.

## Scope

- No nested model, action planner, prompt, subagent, or model-written summary added to direct dispatch.
- No change to the credential-free isolated `CODEX_HOME` or the signed broker path.
- No logging of arguments, typed values, screenshots, app-state/result content, or credentials.
- Focus checks remain post-action detection.

Not a security-boundary change (parsing fix only); happy to get an independent exact-head review if the maintainer prefers.