### PR TITLE
Fix installed Computer Use client resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ nested prompts or result summaries
 
 | Released wrapper restriction | Classification | Direct design |
 |---|---|---|
-| Fixed ChatGPT/Codex/client paths | **official-required** | retained and verified |
+| Reviewed ChatGPT/Codex/client paths | **official-required** | current per-user installed-component contract plus exact legacy plugin layout; canonicalized and verified |
 | Strict signatures and OpenAI Team ID | **security-essential** | retained |
 | Signed-parent/responsible-process chain | **official-required** | retained through signed app-server |
 | Private Sky socket/native-pipe access | **unsupported/private** | prohibited |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Development and live acceptance require macOS and the official ChatGPT Computer 
 - Add a regression test for every protocol, policy, focus, cleanup, or audit fix.
 - Never log or persist arguments, typed values, screenshots, app-state/result content, elicitation contents, prompts, credentials, or tokens.
 - Treat focus checks as post-action detection rather than preventive isolation.
-- Document fixed ChatGPT bundle paths and upstream schema/API assumptions.
+- Document reviewed ChatGPT component paths, launcher contracts, and upstream schema/API assumptions.
 - Include strict core/Pi type checks, tests, build, audit, package inspection, and real-app acceptance evidence.
 - Obtain independent exact-head review for security-boundary changes.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration and rollback
 
-Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 keeps that exact ten-tool contract and adds Pi 0.80.7 progressive disclosure. Use the relevant section below.
+Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 keeps that exact ten-tool contract and adds Pi 0.80.7 progressive disclosure. Version 0.3.1 follows ChatGPT's current per-user Computer Use component layout. Use the relevant section below.
 
 ## What changes
 
@@ -77,6 +77,17 @@ The MCP contract and signed execution path do not change. The native Pi extensio
 
 The change is context disclosure, not a permission mode. Codex Full access, emitted elicitation forwarding, schemas, and the no-permissions policy remain unchanged.
 
+## Upgrade from version 0.3.0 to 0.3.1
+
+ChatGPT 26.721 moved the signed Computer Use app out of the bundled plugin and into `~/.codex/computer-use/`. Version 0.3.1 follows the official launcher contract while retaining the exact former plugin layout as a compatibility candidate.
+
+1. Verify that npm resolves `codex-computer-use-mcp@0.3.1` exactly, then install that exact package.
+2. Start a fresh Pi process. A running Pi process retains the already-loaded extension code.
+3. Verify `/computer-use-status` reports `brokerVerified: true`.
+4. While the Mac is unlocked, run `computer_use_list_apps` and `computer_use_get_app_state` against a benign real app.
+
+The resolver does not read `HOME` or `CODEX_HOME` and has no arbitrary path override. Missing, symlinked, invalidly signed, or wrong-Team-ID clients fail closed.
+
 ## Rollback
 
 1. Stop the current Pi process.
@@ -91,4 +102,4 @@ Direct state can be removed only after rollback evidence is captured and no proc
 
 ## Generic MCP gateway
 
-If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.0` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.
+If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.1` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.

--- a/PROOF.md
+++ b/PROOF.md
@@ -49,7 +49,9 @@ The public OpenAI source basis and permanent links are in `ARCHITECTURE.md`.
 Current branch tests cover:
 
 - strict TypeScript for core and Pi adapter;
-- fixed-path strict signature and Team ID checks;
+- current ChatGPT per-user component resolution plus exact legacy-layout compatibility;
+- missing, symlinked-path, invalid-signature, and wrong-Team-ID resolution failures, including no fallback from a present invalid current client;
+- strict signature and Team ID checks;
 - exact official ten-tool inventory/schema drift rejection before dispatch;
 - direct JSONL request sequence with no `turn/start`;
 - isolated credential-free `CODEX_HOME` even when the parent environment contains a model API key;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Computer Use MCP
 
-Version 0.3.0 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
+Version 0.3.1 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
 
 The primary path has:
 
@@ -12,7 +12,7 @@ The primary path has:
 
 It does use OpenAI's signed `codex app-server` as the official host for the bundled Computer Use MCP client. The current official `mcpServer/tool/call` API requires a loaded thread identifier, so the bridge creates an empty, in-memory, zero-turn context (`ephemeral: true`, `turns: []`, `path: null`). It never calls `turn/start` and fails closed if any `turn/*` or `item/*` model activity appears.
 
-> **Independent project.** This is not an OpenAI product and is not endorsed by OpenAI. The app-server API is marked experimental and fixed ChatGPT bundle paths may change.
+> **Independent project.** This is not an OpenAI product and is not endorsed by OpenAI. The app-server API is marked experimental and ChatGPT's reviewed component locations may change.
 
 ## Direct tools
 
@@ -69,22 +69,24 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for source links and the full restricti
 - Node.js 22 or newer
 - Pi 0.80.7 or newer for native progressive tool disclosure
 - official ChatGPT macOS app at `/Applications/ChatGPT.app`
-- official Computer Use component installed
+- official Computer Use component installed by ChatGPT under `~/.codex/computer-use/`
+
+The bridge follows ChatGPT's current launcher contract for `SkyComputerUseClient` under that per-user component directory. It does not honor `HOME`, `CODEX_HOME`, or an arbitrary path override when resolving the production client. The former exact app-in-plugin layout remains a strict compatibility candidate only when the current component is absent. Every selected client must be at a canonical reviewed path, pass strict code-signature verification, and carry OpenAI Team ID `2DC432GLL2`.
 
 The direct bridge starts app-server with a new private `CODEX_HOME` containing no account credentials and only one configured MCP server: official Computer Use. It does not inherit the user's Codex MCP servers, plugins, history, memories, API keys, or auth file. It selects a non-websocket dummy model provider bound to unreachable loopback, disables plugin/remote-control features, and never starts a turn; this prevents app-server model prewarm or Responses API traffic.
 
 ### Locked-screen limitation
 
-Version 0.3.0 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
+Version 0.3.1 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
 
-OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.0.
+OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.1.
 
 ## Pi integration
 
 Install the exact release from npm:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.0
+pi install npm:codex-computer-use-mcp@0.3.1
 ```
 
 To evaluate a source checkout instead:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,8 +18,8 @@ This is direct tool dispatch—not model orchestration.
 
 ## Security invariants
 
-1. Only fixed app-bundled Codex and Computer Use client paths are allowed in production.
-2. Both binaries pass strict code-signature verification and OpenAI Team ID `2DC432GLL2` checks before dispatch.
+1. Only the fixed app-bundled Codex path and reviewed official Computer Use layouts are allowed in production. The current client is resolved from the OS account home under `~/.codex/computer-use/`; `HOME`, `CODEX_HOME`, arbitrary paths, and symlinked layouts are not accepted. The former exact plugin-bundle layout is considered only when the current component is absent.
+2. Both binaries pass strict code-signature verification and OpenAI Team ID `2DC432GLL2` checks before dispatch. A present current-layout client that fails verification never falls back.
 3. The helper's exact ten method names and input schemas match the pinned expected inventory before every call; release tests also verify its descriptions and annotations.
 4. `no-permissions` is the only wrapper policy: all ten methods are exposed and no wrapper permission prompt is opened.
 5. There is no config file, environment override, command, tool argument, per-call branch, or alternate safe/full route that an agent can select.
@@ -56,6 +56,6 @@ Computer Use returns the official app-state text and screenshots to the invoking
 
 ## Supported versions
 
-Only the latest approved release is supported. Version 0.3.0 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
+Only the latest approved release is supported. Version 0.3.1 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
 
 App-server is experimental and bundle paths or schemas can change. Drift fails closed until reviewed.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -13,10 +13,10 @@ CODEX_COMPUTER_USE_HOME="$(mktemp -d)" \
 
 `-ne` prevents an installed 0.1 adapter from loading at the same time. This source workflow does not install or switch live Pi configuration.
 
-For normal installation, use the exact version 0.3.0 npm package:
+For normal installation, use the exact version 0.3.1 npm package:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.0
+pi install npm:codex-computer-use-mcp@0.3.1
 ```
 
 Use the source workflow only when you need to test an exact reviewed commit. Follow the rollback procedure in `MIGRATION.md` when replacing version 0.1.
@@ -49,7 +49,7 @@ No-permissions is the only policy: all ten tools are registered and available th
 
 ## Generic MCP gateway
 
-Merge `mcp.json.example` only for the exact 0.3.0 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
+Merge `mcp.json.example` only for the exact 0.3.1 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
 
 For a source checkout:
 

--- a/integrations/pi/mcp.json.example
+++ b/integrations/pi/mcp.json.example
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "codex-computer-use-mcp@0.3.0"
+        "codex-computer-use-mcp@0.3.1"
       ],
       "lifecycle": "lazy",
       "requestTimeoutMs": 180000,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-computer-use-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "os": [
         "darwin"
@@ -3664,9 +3664,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Expose the official macOS Computer Use tools directly to Pi and MCP clients without a nested model.",
   "author": "Thomas Mustier",
   "license": "MIT",

--- a/src/direct-broker.ts
+++ b/src/direct-broker.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync, realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -12,7 +13,10 @@ import {
 export const CODEX_PATH = "/Applications/ChatGPT.app/Contents/Resources/codex";
 export const COMPUTER_USE_PLUGIN_ROOT =
 	"/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled/plugins/computer-use";
-export const COMPUTER_USE_CLIENT_PATH = `${COMPUTER_USE_PLUGIN_ROOT}/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient`;
+const COMPUTER_USE_APP_RELATIVE_PATH = "computer-use/Codex Computer Use.app";
+const CLIENT_RELATIVE_PATH = "Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient";
+export const COMPUTER_USE_CLIENT_PATH = path.join(os.userInfo().homedir, ".codex", COMPUTER_USE_APP_RELATIVE_PATH, CLIENT_RELATIVE_PATH);
+export const LEGACY_COMPUTER_USE_CLIENT_PATH = path.join(COMPUTER_USE_PLUGIN_ROOT, "Codex Computer Use.app", CLIENT_RELATIVE_PATH);
 const OPENAI_TEAM_ID = "2DC432GLL2";
 const MAX_PROTOCOL_LINE_BYTES = 8 * 1024 * 1024;
 const MAX_RESULT_BYTES = 25 * 1024 * 1024;
@@ -104,47 +108,97 @@ export class DirectBrokerCallError extends Error {
 	}
 }
 
-function verifySignedBinary(binaryPath: string): void {
-	const verify = spawnSync("/usr/bin/codesign", ["--verify", "--strict", binaryPath], {
-		encoding: "utf8",
-		timeout: 10_000,
-	});
+interface CommandResult {
+	status: number | null;
+	stdout?: string | Buffer;
+	stderr?: string | Buffer;
+}
+
+type RunSync = (command: string, args: string[]) => CommandResult;
+
+function productionRunSync(command: string, args: string[]): CommandResult {
+	return spawnSync(command, args, { encoding: "utf8", timeout: 10_000 });
+}
+
+function verifySignedBinary(binaryPath: string, runSync: RunSync): void {
+	const verify = runSync("/usr/bin/codesign", ["--verify", "--strict", binaryPath]);
 	if (verify.status !== 0) throw new BrokerVerificationError(`Signature verification failed for ${path.basename(binaryPath)}`);
-	const details = spawnSync("/usr/bin/codesign", ["-dv", "--verbose=2", binaryPath], {
-		encoding: "utf8",
-		timeout: 10_000,
-	});
+	const details = runSync("/usr/bin/codesign", ["-dv", "--verbose=2", binaryPath]);
 	const output = `${details.stdout ?? ""}\n${details.stderr ?? ""}`;
-	if (details.status !== 0 || !output.includes(`TeamIdentifier=${OPENAI_TEAM_ID}`)) {
+	if (details.status !== 0 || !new RegExp(`(?:^|\\n)TeamIdentifier=${OPENAI_TEAM_ID}(?:\\n|$)`).test(output)) {
 		throw new BrokerVerificationError(`${path.basename(binaryPath)} is not signed by the expected OpenAI team`);
 	}
 }
 
-function clientBuild(): string {
-	const plist = path.join(
-		COMPUTER_USE_PLUGIN_ROOT,
-		"Codex Computer Use.app",
-		"Contents",
-		"Info.plist",
-	);
-	const result = spawnSync("/usr/bin/plutil", ["-extract", "CFBundleVersion", "raw", plist], {
-		encoding: "utf8",
-		timeout: 5000,
-	});
-	if (result.status !== 0 || !(result.stdout ?? "").trim()) {
-		throw new BrokerVerificationError("Could not verify the official Computer Use client build");
-	}
-	return (result.stdout ?? "").trim();
+export interface OfficialComputerUseClient {
+	clientPath: string;
+	appPath: string;
+	layout: "installed-component" | "legacy-plugin-bundle";
 }
 
-export function verifyOfficialDirectBroker(): { brokerVersion: string; clientBuild: string } {
-	verifySignedBinary(CODEX_PATH);
-	verifySignedBinary(COMPUTER_USE_CLIENT_PATH);
-	const version = spawnSync(CODEX_PATH, ["--version"], { encoding: "utf8", timeout: 5000 });
-	if (version.status !== 0 || !/^codex-cli\s+\d+\./.test((version.stdout ?? "").trim())) {
+interface ResolveOfficialComputerUseClientOptions {
+	/** Test-only OS-account home override. Production never reads HOME or CODEX_HOME. */
+	userHome?: string;
+	/** Test-only legacy root override. */
+	legacyPluginRoot?: string;
+	runSync?: RunSync;
+}
+
+function checkedCandidate(appPath: string, clientPath: string, layout: OfficialComputerUseClient["layout"], runSync: RunSync): OfficialComputerUseClient | undefined {
+	if (!existsSync(clientPath)) return undefined;
+	let canonicalApp: string;
+	let canonicalClient: string;
+	try {
+		canonicalApp = realpathSync(appPath);
+		canonicalClient = realpathSync(clientPath);
+	} catch {
+		throw new BrokerVerificationError("Could not resolve the official Computer Use client path");
+	}
+	if (canonicalApp !== path.resolve(appPath) || canonicalClient !== path.resolve(clientPath) || !canonicalClient.startsWith(`${canonicalApp}${path.sep}`)) {
+		throw new BrokerVerificationError("Official Computer Use client path was not canonical");
+	}
+	verifySignedBinary(canonicalClient, runSync);
+	return { appPath: canonicalApp, clientPath: canonicalClient, layout };
+}
+
+/** Resolve only the two reviewed official layouts, preferring ChatGPT's current installed-component contract. */
+export function resolveOfficialComputerUseClient(options: ResolveOfficialComputerUseClientOptions = {}): OfficialComputerUseClient {
+	const runSync = options.runSync ?? productionRunSync;
+	const userHome = options.userHome ?? os.userInfo().homedir;
+	const canonicalUserHome = existsSync(userHome) ? realpathSync(userHome) : path.resolve(userHome);
+	const currentApp = path.join(canonicalUserHome, ".codex", COMPUTER_USE_APP_RELATIVE_PATH);
+	const current = checkedCandidate(currentApp, path.join(currentApp, CLIENT_RELATIVE_PATH), "installed-component", runSync);
+	if (current) return current;
+
+	const legacyRoot = options.legacyPluginRoot ?? COMPUTER_USE_PLUGIN_ROOT;
+	const canonicalLegacyRoot = existsSync(legacyRoot) ? realpathSync(legacyRoot) : path.resolve(legacyRoot);
+	const legacyApp = path.join(canonicalLegacyRoot, "Codex Computer Use.app");
+	const legacy = checkedCandidate(legacyApp, path.join(legacyApp, CLIENT_RELATIVE_PATH), "legacy-plugin-bundle", runSync);
+	if (legacy) return legacy;
+	throw new BrokerVerificationError("Official Computer Use client was not found in a supported location");
+}
+
+function clientBuild(appPath: string, runSync: RunSync): string {
+	const result = runSync("/usr/bin/plutil", ["-extract", "CFBundleVersion", "raw", path.join(appPath, "Contents", "Info.plist")]);
+	if (result.status !== 0 || !(result.stdout ?? "").toString().trim()) {
+		throw new BrokerVerificationError("Could not verify the official Computer Use client build");
+	}
+	return (result.stdout ?? "").toString().trim();
+}
+
+export function verifyOfficialDirectBroker(options: ResolveOfficialComputerUseClientOptions = {}): {
+	brokerVersion: string;
+	clientBuild: string;
+	client: OfficialComputerUseClient;
+} {
+	const runSync = options.runSync ?? productionRunSync;
+	verifySignedBinary(CODEX_PATH, runSync);
+	const client = resolveOfficialComputerUseClient({ ...options, runSync });
+	const version = runSync(CODEX_PATH, ["--version"]);
+	if (version.status !== 0 || !/^codex-cli\s+\d+\./.test((version.stdout ?? "").toString().trim())) {
 		throw new BrokerVerificationError("Could not verify the app-bundled Codex app-server version");
 	}
-	return { brokerVersion: (version.stdout ?? "").trim(), clientBuild: clientBuild() };
+	return { brokerVersion: (version.stdout ?? "").toString().trim(), clientBuild: clientBuild(client.appPath, runSync), client };
 }
 
 function buildBrokerEnv(codexHome: string, tempRoot: string): NodeJS.ProcessEnv {
@@ -162,8 +216,8 @@ function buildBrokerEnv(codexHome: string, tempRoot: string): NodeJS.ProcessEnv 
 	return env;
 }
 
-export function buildDirectAppServerArgs(mcpCwd = COMPUTER_USE_PLUGIN_ROOT): string[] {
-	const mcpTable = `{"computer-use" = { command = ${JSON.stringify(COMPUTER_USE_CLIENT_PATH)}, args = ["mcp"], cwd = ${JSON.stringify(mcpCwd)}, enabled = true, startup_timeout_sec = 30, tool_timeout_sec = 120 }}`;
+export function buildDirectAppServerArgs(mcpCwd = COMPUTER_USE_PLUGIN_ROOT, clientPath = COMPUTER_USE_CLIENT_PATH): string[] {
+	const mcpTable = `{"computer-use" = { command = ${JSON.stringify(clientPath)}, args = ["mcp"], cwd = ${JSON.stringify(mcpCwd)}, enabled = true, startup_timeout_sec = 30, tool_timeout_sec = 120 }}`;
 	const disabledProvider = '{ name = "Direct dispatch disabled provider", base_url = "http://127.0.0.1:9/v1", wire_api = "responses", request_max_retries = 0, stream_max_retries = 0, supports_websockets = false, requires_openai_auth = false }';
 	return [
 		"-c", 'model_provider="direct_disabled"',
@@ -430,7 +484,7 @@ export async function callOfficialDirectTool(
 ): Promise<DirectBrokerResult> {
 	const startedAt = Date.now();
 	const verification = options.skipSignatureVerification
-		? { brokerVersion: "test-app-server", clientBuild: "test-client" }
+		? { brokerVersion: "test-app-server", clientBuild: "test-client", client: undefined }
 		: verifyOfficialDirectBroker();
 	const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-direct-computer-use."));
 	const codexHome = path.join(tempRoot, "codex-home");
@@ -496,7 +550,7 @@ export async function callOfficialDirectTool(
 
 	try {
 		const command = options.appServerCommand ?? CODEX_PATH;
-		const commandArgs = options.appServerArgs ?? buildDirectAppServerArgs(workDir);
+		const commandArgs = options.appServerArgs ?? buildDirectAppServerArgs(workDir, verification.client!.clientPath);
 		proc = spawn(command, commandArgs, {
 			cwd: workDir,
 			detached: true,
@@ -606,7 +660,7 @@ export async function callOfficialDirectTool(
 		await request(
 			"initialize",
 			{
-				clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.0" },
+				clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.1" },
 				capabilities: { mcpServerOpenaiFormElicitation: options.supportsOpenAiFormElicitation === true && options.onElicitation !== undefined },
 			},
 			15_000,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,7 @@ import {
 	OFFICIAL_TOOL_METADATA,
 } from "./tools.ts";
 
-const version = "0.3.0";
+const version = "0.3.1";
 
 async function handleCli(): Promise<boolean> {
 	const args = process.argv.slice(2);

--- a/test/client-resolution.test.ts
+++ b/test/client-resolution.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { realpathSync } from "node:fs";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+	BrokerVerificationError,
+	resolveOfficialComputerUseClient,
+} from "../src/direct-broker.ts";
+
+const CLIENT_RELATIVE_PATH = "Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient";
+
+async function makeClient(appPath: string): Promise<string> {
+	const clientPath = path.join(appPath, CLIENT_RELATIVE_PATH);
+	await mkdir(path.dirname(clientPath), { recursive: true });
+	await writeFile(clientPath, "signed fixture\n", { mode: 0o700 });
+	return clientPath;
+}
+
+function signedBy(team = "2DC432GLL2") {
+	return (_command: string, args: string[]) => {
+		if (args.includes("--verify")) return { status: 0, stdout: "", stderr: "" };
+		return { status: 0, stdout: "", stderr: `TeamIdentifier=${team}\n` };
+	};
+}
+
+test("resolves and verifies ChatGPT's current per-user installed component path", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "cu-current-resolution."));
+	try {
+		const appPath = path.join(root, ".codex", "computer-use", "Codex Computer Use.app");
+		const clientPath = await makeClient(appPath);
+		const resolved = resolveOfficialComputerUseClient({
+			userHome: root,
+			legacyPluginRoot: path.join(root, "missing-legacy"),
+			runSync: signedBy(),
+		});
+		assert.deepEqual(resolved, { appPath: realpathSync(appPath), clientPath: realpathSync(clientPath), layout: "installed-component" });
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("fails closed when no supported client path exists", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "cu-missing-resolution."));
+	try {
+		assert.throws(
+			() => resolveOfficialComputerUseClient({ userHome: root, legacyPluginRoot: path.join(root, "legacy"), runSync: signedBy() }),
+			/was not found in a supported location/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("fails closed on an invalid client signature without falling back", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "cu-invalid-signature."));
+	try {
+		await makeClient(path.join(root, ".codex", "computer-use", "Codex Computer Use.app"));
+		await makeClient(path.join(root, "legacy", "Codex Computer Use.app"));
+		assert.throws(
+			() => resolveOfficialComputerUseClient({
+				userHome: root,
+				legacyPluginRoot: path.join(root, "legacy"),
+				runSync: () => ({ status: 1, stdout: "", stderr: "invalid" }),
+			}),
+			/Signature verification failed/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("fails closed when the client has the wrong signing Team ID", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "cu-wrong-team."));
+	try {
+		await makeClient(path.join(root, ".codex", "computer-use", "Codex Computer Use.app"));
+		assert.throws(
+			() => resolveOfficialComputerUseClient({ userHome: root, legacyPluginRoot: path.join(root, "legacy"), runSync: signedBy("NOT_OPENAI") }),
+			/not signed by the expected OpenAI team/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("rejects a symlinked client layout rather than accepting an arbitrary resolved path", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "cu-symlink-path."));
+	try {
+		const actualApp = path.join(root, "elsewhere", "Codex Computer Use.app");
+		await makeClient(actualApp);
+		const expectedParent = path.join(root, ".codex", "computer-use");
+		await mkdir(expectedParent, { recursive: true });
+		await symlink(actualApp, path.join(expectedParent, "Codex Computer Use.app"));
+		assert.throws(
+			() => resolveOfficialComputerUseClient({ userHome: root, legacyPluginRoot: path.join(root, "legacy"), runSync: signedBy() }),
+			/was not canonical/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("retains the strict legacy plugin-bundle layout when the current component is absent", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "cu-legacy-resolution."));
+	try {
+		const appPath = path.join(root, "legacy", "Codex Computer Use.app");
+		const clientPath = await makeClient(appPath);
+		const resolved = resolveOfficialComputerUseClient({ userHome: root, legacyPluginRoot: path.join(root, "legacy"), runSync: signedBy() });
+		assert.deepEqual(resolved, { appPath: realpathSync(appPath), clientPath: realpathSync(clientPath), layout: "legacy-plugin-bundle" });
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/test/official-broker.test.ts
+++ b/test/official-broker.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import test from "node:test";
-import { COMPUTER_USE_CLIENT_PATH, verifyOfficialDirectBroker } from "../src/direct-broker.ts";
+import { verifyOfficialDirectBroker } from "../src/direct-broker.ts";
 import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA } from "../src/tools.ts";
 
 function rpc(proc: ReturnType<typeof spawn>, id: number, method: string, params: unknown): Promise<any> {
@@ -32,7 +32,8 @@ test("official signed app-server broker and exact ten-tool helper inventory are 
 	const verified = verifyOfficialDirectBroker();
 	assert.match(verified.brokerVersion, /^codex-cli\s+\d+\./);
 	assert.match(verified.clientBuild, /^\d+$/);
-	const proc = spawn(COMPUTER_USE_CLIENT_PATH, ["mcp"], { stdio: ["pipe", "pipe", "ignore"] });
+	assert.equal(verified.client.layout, "installed-component");
+	const proc = spawn(verified.client.clientPath, ["mcp"], { stdio: ["pipe", "pipe", "ignore"] });
 	try {
 		const initialized = await rpc(proc, 1, "initialize", {
 			protocolVersion: "2025-11-25",


### PR DESCRIPTION
## Summary

- follow ChatGPT's current launcher contract and resolve the signed client from the OS account's `~/.codex/computer-use/` component
- retain only the exact former plugin-bundle layout when the current component is absent
- reject missing, symlinked/non-canonical, invalidly signed, and wrong-Team-ID clients without fallback from a present invalid current client
- prepare patch release 0.3.1 and update installation/migration docs

Closes #7

## Security boundary

Production resolution does not honor `HOME`, `CODEX_HOME`, environment variables, or arbitrary paths. Both app-server and client still require strict code-signature verification and OpenAI Team ID `2DC432GLL2`; the exact ten-tool schema/inventory and zero-turn fail-closed checks are unchanged.

## Validation

- `npm ci`: pass
- `npm run check`: pass
- `npm run check:pi`: pass
- `npm test`: 65/65 pass
- `npm run build`: pass
- `npm pack --dry-run --json --ignore-scripts`: pass (40 files)
- official signed helper inventory/schema smoke: pass against installed build 1000502
- source live `list_apps`: pass through signed app-server, zero turns, cleanup verified
- source live `get_app_state` against Chrome: reaches the official service but cannot complete while the host is locked (`-10005 cgWindowNotFound`); fresh unlocked Pi acceptance remains required before issue close

## Audit note

`npm audit --omit=dev` currently reports GHSA-frvp-7c67-39w9 through latest MCP SDK 1.29.0's `@hono/node-server` 1.x range. The advisory is limited to Windows `serve-static`; this package is Darwin-only and uses stdio. No compatible upstream dependency fix exists without forcing an unrelated transitive major. Merge/release awaits maintainer approval of the scoped non-applicability waiver.
