### PR TITLE
Fix Pi Computer Use tool and session continuity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@ The relevant construction difference is the macOS responsible-process chain:
 - unsupported: ad-hoc/no-Team-ID Node parent → signed helper;
 - supported: Node/Pi → strict-valid OpenAI-signed app-bundled Codex (`2DC432GLL2`) → strict-valid OpenAI-signed helper (`2DC432GLL2`).
 
-Process sampling confirmed the helper children were direct descendants of signed app-server; helper processes may create their own process groups. App-server and helper therefore share one private per-call cwd. Cleanup preserves partial ancestry results, recovers any reparented process by that unique cwd, freezes the owned set to stability, then kills and verifies every process rather than assuming one PGID. Enumeration, freeze, or exit uncertainty fails cleanup closed. The app-server has the expected sandbox/application-group entitlement keys; the helper has OpenAI application/team identifiers, application groups, and keychain-access-group entitlements. Ordinary Node has no Team ID or entitlement set. The service's peer audit token is not exposed through the supported MCP layer. No private socket inspection, identity spoofing, copied signing material, re-signing, injection, or TCC change was attempted. The remaining enforcement boundary is therefore OS peer/responsible-process identity, not a missing public JSON field.
+Process sampling confirmed the helper children were direct descendants of signed app-server; helper processes may create their own process groups. App-server and helper therefore share one private broker-session cwd. One-shot MCP calls close that session after the call; Pi retains it only across the required `get_app_state` and following action. Cleanup preserves partial ancestry results, recovers any reparented process by that unique cwd, freezes the owned set to stability, then kills and verifies every process rather than assuming one PGID. Enumeration, freeze, or exit uncertainty fails cleanup closed. The app-server has the expected sandbox/application-group entitlement keys; the helper has OpenAI application/team identifiers, application groups, and keychain-access-group entitlements. Ordinary Node has no Team ID or entitlement set. The service's peer audit token is not exposed through the supported MCP layer. No private socket inspection, identity spoofing, copied signing material, re-signing, injection, or TCC change was attempted. The remaining enforcement boundary is therefore OS peer/responsible-process identity, not a missing public JSON field.
 
 Command, environment, cwd, and config differences were also isolated: both paths invoke the same signed helper with `mcp`; the accepted path gives it a signed parent plus a private fixed cwd/config environment. Matching public MCP fields did not alter the raw error, while the signed-parent path succeeds without model credentials.
 
@@ -119,7 +119,7 @@ nested prompts or result summaries
 | Automatic background app launch | **accidental** | removed; the official tool owns app behavior |
 | Global focus watcher and final sample | **security-essential detection** | retained |
 | Timeout/cancellation process-tree termination | **security-essential** | retained with strict enumeration, freeze, kill, stdio-close, and exit verification |
-| Per-call temporary worker cleanup | **security-essential** | retained with isolated `CODEX_HOME` |
+| Temporary broker-session cleanup | **security-essential** | retained with isolated `CODEX_HOME`; Pi closes after the inspection-action pair, replacement inspection, or session shutdown |
 | Codex token usage accounting | **compatibility-only** | removed; no model turn exists |
 | Content-safe private audit | **security-essential** | retained with direct-call fields |
 | Full-result spill files | **unsafe/accidental** | prohibited; truncation is in-memory only |
@@ -133,11 +133,13 @@ App-server is created with `approvalPolicy: "never"` and `sandbox: "danger-full-
 
 The broker still handles any `mcpServer/elicitation/request` that app-server emits. Pi advertises OpenAI-form support and renders emitted form, OpenAI-form, and URL requests. Generic stdio MCP forwards supported standard modes as `elicitation/create`. The response path preserves `accept`, `decline`, `cancel`, structured content, and response metadata; no callback or compatible UI yields `cancel`, never an invented decision.
 
-## Pi tool disclosure boundary
+## Pi tool and session boundary
 
-The Pi extension registers all ten official definitions. On `session_start` it preserves active tools owned by Pi and other extensions, keeps `computer_use_list_apps` and `computer_use_get_app_state` active, and removes only the eight Computer Use interaction definitions from the initial active set. After a successful `get_app_state` result, it additively activates those eight definitions without removing any currently active tool.
+The Pi extension registers and activates all ten official definitions on `session_start`, additively preserving active tools owned by Pi and other extensions. Keeping inspection and interaction methods on the same direct surface avoids provider-bound tool discovery creating a second, incompatible client binding.
 
-This is context disclosure, not a wrapper permission gate. The schemas, execution path, and no-permissions policy do not change. Loader and interaction definitions remain registered throughout the session. The interaction definitions omit `promptSnippet` and `promptGuidelines`, allowing Pi 0.80.7's native deferred-loading representation to add schemas at the tool-result position without changing the system-prompt prefix. Providers without native support use Pi's next-request fallback.
+For `get_app_state`, Pi starts one verified zero-turn app-server runtime and signed Computer Use client. The following direct interaction is serialized through that same runtime and thread, preserving the official active-app lease. The retained process tree is closed and verified after the action, before a replacement inspection, or during `session_shutdown`. One-shot MCP calls still start and close a broker session within the call. Exact inventory and schemas are revalidated before every dispatch in either path.
+
+This lifecycle changes neither the schemas nor the no-permissions policy. Interaction definitions omit extra `promptSnippet` and `promptGuidelines` metadata and rely on their official descriptions.
 
 ## Output boundary
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration and rollback
 
-Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 keeps that exact ten-tool contract and adds Pi 0.80.7 progressive disclosure. Version 0.3.1 follows ChatGPT's current per-user Computer Use component layout. Use the relevant section below.
+Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 added Pi progressive disclosure, version 0.3.1 followed ChatGPT's current per-user Computer Use component layout, and version 0.3.2 restores one complete direct Pi surface with shared inspection-action session continuity. Use the relevant section below.
 
 ## What changes
 
@@ -88,6 +88,18 @@ ChatGPT 26.721 moved the signed Computer Use app out of the bundled plugin and i
 
 The resolver does not read `HOME` or `CODEX_HOME` and has no arbitrary path override. Missing, symlinked, invalidly signed, or wrong-Team-ID clients fail closed.
 
+## Upgrade from version 0.3.1 to 0.3.2
+
+Version 0.3.2 activates all ten direct Pi tools at session start and retains one verified signed-client session across `get_app_state` and the following action.
+
+1. Verify that npm resolves `codex-computer-use-mcp@0.3.2` exactly, then install that exact package.
+2. Start a fresh Pi process; do not rely on hot reload for the retained process lifecycle.
+3. Verify all ten `computer_use_*` tools are active through the direct extension binding.
+4. With an unlocked Mac and a benign background app, call `computer_use_get_app_state`, then one harmless interaction against the same app.
+5. Verify the state and action used one app-server runtime/thread, the action did not report an inactive Computer Use session, focus remained preserved, and cleanup completed.
+
+The exact schemas, strict signature and OpenAI Team ID checks, canonical client and app resolution, Full access policy, zero-turn attestation, inventory validation, kernel lock, focus telemetry, process-tree cleanup, and content-safe audit remain mandatory.
+
 ## Rollback
 
 1. Stop the current Pi process.
@@ -102,4 +114,4 @@ Direct state can be removed only after rollback evidence is captured and no proc
 
 ## Generic MCP gateway
 
-If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.1` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.
+If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.2` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.

--- a/PROOF.md
+++ b/PROOF.md
@@ -76,8 +76,8 @@ Current branch tests cover:
 - signed app-server elicitation forwarding, exact user responses, headless cancellation, and cancellation while a UI callback is pending;
 - standard form/URL forwarding across a real MCP SDK client/server transport;
 - Pi source registration for every direct capability with no nested planner, permission command, or wrapper-generated approval UI;
-- Pi session-start disclosure of only the two inspection definitions while preserving unrelated active tools;
-- purely additive activation of all eight interaction definitions after successful `get_app_state`, with no lazy-tool prompt metadata;
+- Pi session-start registration and activation of all ten direct definitions while preserving unrelated active tools;
+- one retained broker/client session across `get_app_state` and the following action, with deterministic active-app lease continuity and verified close;
 - Pi form, opaque OpenAI-form, URL, decline, and headless-cancel elicitation handling.
 
 ## Official Full access approval probe
@@ -119,7 +119,10 @@ Evidence:
 
 Earlier exploratory attempts exposed and fixed two acceptance-quality issues rather than being counted as proof: common `CMD+A` needed normalization to the official `Meta_L+a` key form, and TextEdit state restoration had to be reset before a fresh run. The final evidence above is from the corrected direct path.
 
-## Pi 0.80.7 progressive-disclosure measurement
+## Historical Pi 0.80.7 progressive-disclosure measurement
+
+This measurement describes version 0.3.0 and 0.3.1. Version 0.3.2 intentionally supersedes progressive disclosure because it could leave direct interaction tools absent or make a provider-discovered interaction use a different client from direct `get_app_state`.
+
 
 A fresh Pi 0.80.7 process loaded only the source Computer Use extension plus a read-only observer. All ten definitions were registered. The initial active Computer Use set was exactly:
 
@@ -130,7 +133,7 @@ Serializing names, descriptions, schemas, and prompt guidelines measured 6,063 b
 
 A second fresh process exercised the exported activation path from inside a tool execution. Pi's tool result recorded the exact eight interaction names in `addedToolNames`; the before/after active sets retained both inspection tools and removed zero tools. The lazily activated definitions had no `promptSnippet` or `promptGuidelines`.
 
-With `openai-codex/gpt-5.6-sol`, the first request reported 5,723 uncached input tokens. The immediately following request after additive activation reported 1,008 uncached input tokens and 5,632 cache-read tokens. This is live provider evidence that the initial prefix remained reusable while Pi inserted the eight definitions at the tool-result load point. The activation probe used the same `activateInteractionTools` function called after a successful production `get_app_state`; automated tests bind that successful-result branch and exact additive set.
+With `openai-codex/gpt-5.6-sol`, the first request reported 5,723 uncached input tokens. The immediately following request after additive activation reported 1,008 uncached input tokens and 5,632 cache-read tokens. This was live provider evidence that the initial prefix remained reusable while Pi inserted the eight definitions at the tool-result load point. Version 0.3.2 removes that activation path in favor of complete direct registration and signed-client session continuity.
 
 ## Review and release status
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Computer Use MCP
 
-Version 0.3.1 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
+Version 0.3.2 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
 
 The primary path has:
 
@@ -33,9 +33,9 @@ Pi registers namespaced tools to avoid collisions with Pi's built-ins. The MCP s
 
 The MCP façade preserves the official signed helper's tool descriptions, input schemas, and annotations exactly. The Pi façade preserves its descriptions and input schemas; Pi's tool API does not expose MCP annotations. In particular, all ten MCP methods have `destructiveHint: false`; the wrapper does not conflate changing UI state with destructive behavior or add argument restrictions absent from the official schemas.
 
-Pi 0.80.7 and newer registers all ten definitions but initially activates only `computer_use_list_apps` and `computer_use_get_app_state`. A successful `get_app_state` call additively activates the eight interaction definitions for the following model request. Other active Pi and extension tools remain active. The lazily activated tools omit `promptSnippet` and `promptGuidelines`, allowing Pi's native deferred-loading path to preserve the stable system-prompt prefix.
+Pi registers and activates all ten definitions together in every fresh session, while preserving active tools owned by Pi and other extensions. This prevents interaction methods from being absent or loaded through an incompatible provider binding.
 
-As the official contract specifies, Pi—not a nested planner—calls `computer_use_get_app_state` once per assistant turn before interacting with an app, then chooses and executes actions itself.
+As the official contract specifies, Pi—not a nested planner—calls `computer_use_get_app_state` once per assistant turn before interacting with an app, then chooses and executes actions itself. The adapter retains one verified app-server runtime and signed Computer Use client for that inspection-action pair, so the action reuses the official active-app session established by `get_app_state`. It closes and verifies the retained process tree after the action, when a new inspection supersedes it, or on Pi session shutdown.
 
 ## Authorization policy: durable no-permissions
 
@@ -67,7 +67,7 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for source links and the full restricti
 
 - macOS
 - Node.js 22 or newer
-- Pi 0.80.7 or newer for native progressive tool disclosure
+- Pi 0.80.7 or newer
 - official ChatGPT macOS app at `/Applications/ChatGPT.app`
 - official Computer Use component installed by ChatGPT under `~/.codex/computer-use/`
 
@@ -77,16 +77,16 @@ The direct bridge starts app-server with a new private `CODEX_HOME` containing n
 
 ### Locked-screen limitation
 
-Version 0.3.1 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
+Version 0.3.2 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
 
-OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.1.
+OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.2.
 
 ## Pi integration
 
 Install the exact release from npm:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.1
+pi install npm:codex-computer-use-mcp@0.3.2
 ```
 
 To evaluate a source checkout instead:
@@ -103,7 +103,7 @@ Command:
 /computer-use-status
 ```
 
-The native Pi adapter is the primary product path. It registers all ten typed tools directly, starts each session with the two inspection tools active, and additively activates the eight interaction tools after successful app inspection. It exposes no mode-changing command or wrapper-generated approval UI. Official app-access approval elicitations are resolved by Codex Full access before they reach Pi. Any elicitation that app-server does emit is shown through Pi's UI, and only the user's choice is returned to the service.
+The native Pi adapter is the primary product path. It registers and activates all ten typed tools directly, and routes the required `get_app_state` and following action through one retained signed-client session. It exposes no mode-changing command or wrapper-generated approval UI. Official app-access approval elicitations are resolved by Codex Full access before they reach Pi. Any elicitation that app-server does emit is shown through Pi's UI, and only the user's choice is returned to the service.
 
 ## MCP server
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,11 +28,11 @@ This is direct tool dispatch—not model orchestration.
 8. Same-app work is excluded across native Pi, generic MCP, and custom state roots with one fixed per-user kernel `lockf` lease namespace.
 9. Target focus events, periodic samples, watcher health, queued ASN resolution, and final state are checked. This is post-action detection, not a preventive OS sandbox.
 10. One direct request emits one official `mcpServer/tool/call`; no model turn, subagent, shell, web, plugin, prompt, or reachable model transport is available.
-11. App-server and helper share one private per-call working directory. Cleanup combines strict ancestry enumeration (preserving partial results) with working-directory ownership recovery, freezes processes to a stable set, kills every owned process, awaits stdio closure, and verifies exit. This still finds a helper reparented by an early app-server exit; enumeration/freeze/exit uncertainty is fatal.
+11. App-server and helper share one private broker-session working directory. One-shot calls close it immediately; Pi retains it only across the required `get_app_state` and following action, then closes it after the action, before replacement inspection, or on session shutdown. Cleanup combines strict ancestry enumeration (preserving partial results) with working-directory ownership recovery, freezes processes to a stable set, kills every owned process, awaits stdio closure, and verifies exit. This still finds a helper reparented by an early app-server exit; enumeration/freeze/exit uncertainty is fatal.
 12. Protocol JSONL is bounded before an unterminated line can exceed 8 MB in memory.
 13. Per-call `CODEX_HOME` and work directories are mode-private and recursively removed.
 14. Only validated text/image result blocks cross to the invoking client. No full-result spill file is written.
-15. Audits contain metadata only, including separate `brokerCleanupVerified` and `appLeaseReleased` evidence; lease-release failure changes the audited outcome before surfacing. Arguments, values, screenshots, app-state text, result content, prompts, approvals, credentials, and tokens are forbidden.
+15. Audits contain metadata only, including separate `brokerCleanupVerified` and `appLeaseReleased` evidence. A retained Pi inspection truthfully records broker cleanup as pending (`false`); the paired action does not return if final retained-session cleanup fails. Lease-release failure changes the audited outcome before surfacing. Arguments, values, screenshots, app-state text, result content, prompts, approvals, credentials, and tokens are forbidden.
 16. Policy rejections are audited; audit failure is fatal once a secure state path exists.
 17. Runtime and development dependency tarballs are exact-pinned with integrity in `npm-shrinkwrap.json`.
 
@@ -56,6 +56,6 @@ Computer Use returns the official app-state text and screenshots to the invoking
 
 ## Supported versions
 
-Only the latest approved release is supported. Version 0.3.1 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
+Only the latest approved release is supported. Version 0.3.2 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
 
 App-server is experimental and bundle paths or schemas can change. Drift fails closed until reviewed.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,6 +1,6 @@
 # Pi integration
 
-The native Pi adapter is the primary 0.3 path. It registers ten namespaced typed tools so Pi itself chooses each official Computer Use method and argument. Pi 0.80.7 or newer exposes them progressively without changing the ten-tool contract.
+The native Pi adapter is the primary 0.3 path. It registers and activates ten namespaced typed tools together so Pi itself chooses each official Computer Use method and argument.
 
 ## Source checkout acceptance
 
@@ -13,23 +13,20 @@ CODEX_COMPUTER_USE_HOME="$(mktemp -d)" \
 
 `-ne` prevents an installed 0.1 adapter from loading at the same time. This source workflow does not install or switch live Pi configuration.
 
-For normal installation, use the exact version 0.3.1 npm package:
+For normal installation, use the exact version 0.3.2 npm package:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.1
+pi install npm:codex-computer-use-mcp@0.3.2
 ```
 
 Use the source workflow only when you need to test an exact reviewed commit. Follow the rollback procedure in `MIGRATION.md` when replacing version 0.1.
 
 ## Registered surface
 
-Initially active:
+All ten tools are registered and active from session start:
 
 - `computer_use_list_apps`
 - `computer_use_get_app_state`
-
-Registered and activated after a successful `get_app_state` call:
-
 - `computer_use_click`
 - `computer_use_perform_secondary_action`
 - `computer_use_set_value`
@@ -43,13 +40,15 @@ Command:
 
 - `/computer-use-status`
 
-The session-start narrowing preserves every active tool owned by Pi or another extension. Activation after inspection is purely additive: both inspection tools remain active, and the adapter does not remove or replace any tool in that call. The lazily activated tools rely on their official descriptions and omit `promptSnippet` and `promptGuidelines`, so native deferred schema loading does not rebuild the system prompt. Supported Anthropic and OpenAI models receive the definitions at the inspection result; other models receive Pi's normal active-tool fallback on the next request.
+Session-start activation is purely additive and preserves every active tool owned by Pi or another extension. The interaction definitions rely on their official descriptions and omit extra prompt metadata.
+
+A successful `get_app_state` retains its verified app-server runtime, thread, and signed Computer Use client. The following direct interaction uses that same client and official active-app lease, then closes the retained process tree with strict cleanup verification. A new inspection replaces and closes any earlier retained session; Pi `session_shutdown` also closes it.
 
 No-permissions is the only policy: all ten tools are registered and available through this lifecycle with no wrapper permission prompts, mode selector, or app/intent/action gate. The signed host runs with Codex Full access (`approvalPolicy: "never"`, `sandbox: "danger-full-access"`), so normal empty-schema Computer Use app approvals are accepted by Codex before they reach Pi. Pi renders any form, OpenAI-form, or URL elicitation app-server does emit. The user's `accept`, `decline`, or `cancel` response is returned unchanged; the adapter never fabricates one.
 
 ## Generic MCP gateway
 
-Merge `mcp.json.example` only for the exact 0.3.1 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
+Merge `mcp.json.example` only for the exact 0.3.2 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
 
 For a source checkout:
 

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -4,9 +4,11 @@ import { getAgentDir, truncateHead, type ExtensionAPI } from "@earendil-works/pi
 import { Text } from "@earendil-works/pi-tui";
 import { Type, type TSchema } from "typebox";
 import { executeDirectTool, getDirectStatus } from "../../dist/direct-service.js";
-import type {
-  DirectBrokerElicitationRequest,
-  DirectBrokerElicitationResponse,
+import {
+  createOfficialDirectToolSession,
+  type DirectBrokerElicitationRequest,
+  type DirectBrokerElicitationResponse,
+  type OfficialDirectToolSession,
 } from "../../dist/direct-broker.js";
 import { OFFICIAL_TOOL_METADATA, type DirectMethod } from "../../dist/tools.js";
 
@@ -82,15 +84,94 @@ export const INTERACTION_TOOL_NAMES = [
   "computer_use_type_text",
 ] as const;
 
+export const COMPUTER_USE_TOOL_NAMES = [
+  ...INSPECTION_TOOL_NAMES,
+  ...INTERACTION_TOOL_NAMES,
+] as const;
+
 export function setInitialComputerUseTools(pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools">): void {
-  const interactionTools = new Set<string>(INTERACTION_TOOL_NAMES);
-  const preserved = pi.getActiveTools().filter((name) => !interactionTools.has(name));
-  pi.setActiveTools([...new Set([...preserved, ...INSPECTION_TOOL_NAMES])]);
+  pi.setActiveTools([...new Set([...pi.getActiveTools(), ...COMPUTER_USE_TOOL_NAMES])]);
 }
 
-export function activateInteractionTools(pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools">): void {
-  const active = pi.getActiveTools();
-  pi.setActiveTools([...new Set([...active, ...INTERACTION_TOOL_NAMES])]);
+interface SessionExecutorDependencies {
+  createSession?: typeof createOfficialDirectToolSession;
+  executeTool?: typeof executeDirectTool;
+}
+
+/** Keep the signed app-server/client alive across the required state -> action pair. */
+export class PiDirectSessionExecutor {
+  private session: OfficialDirectToolSession | undefined;
+  private queue: Promise<void> = Promise.resolve();
+  private readonly dependencies: SessionExecutorDependencies;
+
+  constructor(dependencies: SessionExecutorDependencies = {}) {
+    this.dependencies = dependencies;
+  }
+
+  private async closeSession(): Promise<void> {
+    const session = this.session;
+    this.session = undefined;
+    await session?.close();
+  }
+
+  async execute(
+    method: DirectMethod,
+    params: Record<string, unknown>,
+    dependencies: Parameters<typeof executeDirectTool>[1],
+  ): Promise<Awaited<ReturnType<typeof executeDirectTool>>> {
+    const previous = this.queue;
+    let release!: () => void;
+    this.queue = new Promise<void>((resolve) => { release = resolve; });
+    await previous;
+    try {
+      const executeTool = this.dependencies.executeTool ?? executeDirectTool;
+      if (method === "list_apps") return await executeTool({ method, arguments: params }, dependencies);
+      if (method === "get_app_state") {
+        await this.closeSession();
+        const createSession = this.dependencies.createSession ?? createOfficialDirectToolSession;
+        try {
+          const response = await executeTool(
+            { method, arguments: params },
+            {
+              ...dependencies,
+              callTool: async (directMethod, args, options) => {
+                this.session = await createSession({ supportsOpenAiFormElicitation: true });
+                return this.session.call(directMethod, args, options);
+              },
+            },
+          );
+          if (response.isError) await this.closeSession();
+          return response;
+        } catch (error) {
+          await this.closeSession();
+          throw error;
+        }
+      }
+      const session = this.session;
+      try {
+        return await executeTool(
+          { method, arguments: params },
+          session ? {
+            ...dependencies,
+            callTool: async (directMethod, args, options) => {
+              const result = await session.call(directMethod, args, options);
+              await this.closeSession();
+              return { ...result, brokerCleanupVerified: true };
+            },
+          } : dependencies,
+        );
+      } finally {
+        await this.closeSession();
+      }
+    } finally {
+      release();
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.queue;
+    await this.closeSession();
+  }
 }
 
 function toPiContent(content: Array<Record<string, unknown>>): Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> {
@@ -188,6 +269,7 @@ export async function handleOfficialElicitation(
 
 export default function directComputerUse(pi: ExtensionAPI) {
   const stateRoot = process.env.CODEX_COMPUTER_USE_HOME || path.join(getAgentDir(), "direct-computer-use");
+  const sessionExecutor = new PiDirectSessionExecutor();
 
   pi.registerCommand("computer-use-status", {
     description: "Show the direct-call architecture, durable no-permissions policy, signed broker, and private audit path",
@@ -214,8 +296,9 @@ export default function directComputerUse(pi: ExtensionAPI) {
       ...inspectionPromptMetadata,
       parameters: ToolParameters[method] as any,
       async execute(_toolCallId, params, signal, onUpdate, ctx) {
-        const response = await executeDirectTool(
-          { method, arguments: params as Record<string, unknown> },
+        const response = await sessionExecutor.execute(
+          method,
+          params as Record<string, unknown>,
           {
             stateRoot,
             signal,
@@ -232,7 +315,6 @@ export default function directComputerUse(pi: ExtensionAPI) {
           },
         );
         if (response.isError) throw new Error(errorText(response.content));
-        if (method === "get_app_state") activateInteractionTools(pi);
         return { content: toPiContent(response.content), details: response.details };
       },
       renderCall(args, theme) {
@@ -244,4 +326,5 @@ export default function directComputerUse(pi: ExtensionAPI) {
   }
 
   pi.on("session_start", () => setInitialComputerUseTools(pi));
+  pi.on("session_shutdown", () => sessionExecutor.close());
 }

--- a/integrations/pi/mcp.json.example
+++ b/integrations/pi/mcp.json.example
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "codex-computer-use-mcp@0.3.1"
+        "codex-computer-use-mcp@0.3.2"
       ],
       "lifecycle": "lazy",
       "requestTimeoutMs": 180000,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-computer-use-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Expose the official macOS Computer Use tools directly to Pi and MCP clients without a nested model.",
   "author": "Thomas Mustier",
   "license": "MIT",

--- a/src/direct-broker.ts
+++ b/src/direct-broker.ts
@@ -45,7 +45,7 @@ export interface DirectBrokerResult {
 	elicitationRequests: number;
 	modelTurnsStarted: 0;
 	ephemeralThread: true;
-	brokerCleanupVerified: true;
+	brokerCleanupVerified: boolean;
 }
 
 export interface DirectBrokerOptions {
@@ -477,12 +477,23 @@ async function terminateGroup(
 	if (cleanupError) throw cleanupError;
 }
 
-export async function callOfficialDirectTool(
-	method: DirectMethod,
-	args: DirectToolArguments,
+export interface OfficialDirectToolSession {
+	call(
+		method: DirectMethod,
+		args: DirectToolArguments,
+		options?: Pick<DirectBrokerOptions, "timeoutMs" | "signal" | "onElicitation" | "supportsOpenAiFormElicitation">,
+	): Promise<DirectBrokerResult>;
+	close(): Promise<void>;
+}
+
+/**
+ * Start one verified app-server runtime and retain its signed Computer Use MCP
+ * client across calls. Pi uses this for the required get_app_state -> action
+ * sequence; one-shot callers continue to use callOfficialDirectTool below.
+ */
+export async function createOfficialDirectToolSession(
 	options: DirectBrokerOptions = {},
-): Promise<DirectBrokerResult> {
-	const startedAt = Date.now();
+): Promise<OfficialDirectToolSession> {
 	const verification = options.skipSignatureVerification
 		? { brokerVersion: "test-app-server", clientBuild: "test-client", client: undefined }
 		: verifyOfficialDirectBroker();
@@ -497,17 +508,17 @@ export async function callOfficialDirectTool(
 	let proc: ChildProcessWithoutNullStreams | undefined;
 	let processClosed: Promise<void> | undefined;
 	let termination: Promise<void> | undefined;
-	let abortHandler: (() => void) | undefined;
 	let fatalError: Error | undefined;
 	let stderr = "";
 	let nextId = 1;
-	let elicitationRequests = 0;
 	let modelTurnsStarted = 0;
-	let directCalls = 0;
 	let ephemeralThread = false;
-	let finalResult: DirectBrokerResult | undefined;
-	let primaryError: Error | undefined;
-	let cleanupVerified = false;
+	let threadId = "";
+	let closed = false;
+	let closePromise: Promise<void> | undefined;
+	let callActive = false;
+	let currentElicitation: DirectBrokerOptions["onElicitation"];
+	let currentElicitationCount = 0;
 	const pending = new Map<string, { resolve(value: unknown): void; reject(error: Error): void; timer: NodeJS.Timeout }>();
 	const rejectAll = (error: Error): void => {
 		for (const waiter of pending.values()) {
@@ -534,18 +545,42 @@ export async function callOfficialDirectTool(
 		return new Promise((resolve, reject) => {
 			const timer = setTimeout(() => {
 				pending.delete(id);
-				reject(new Error(`Official app-server request timed out: ${methodName}`));
-				void ensureTerminated().catch(() => undefined);
+				const error = new Error(`Official app-server request timed out: ${methodName}`);
+				reject(error);
+				fail(error);
 			}, timeoutMs);
 			pending.set(id, { resolve, reject, timer });
-			try {
-				send({ method: methodName, id, params });
-			} catch (error) {
+			try { send({ method: methodName, id, params }); }
+			catch (error) {
 				clearTimeout(timer);
 				pending.delete(id);
 				reject(error instanceof Error ? error : new Error(String(error)));
 			}
 		});
+	};
+
+	const close = (): Promise<void> => {
+		closePromise ??= (async () => {
+			closed = true;
+			rejectAll(new Error("Official app-server closed"));
+			let cleanupError: Error | undefined;
+			try {
+				await ensureTerminated();
+				if (processClosed) {
+					await new Promise<void>((resolve, reject) => {
+						const timer = setTimeout(() => reject(new Error("Official app-server stdio did not close")), 1_000);
+						processClosed!.then(() => { clearTimeout(timer); resolve(); });
+					});
+				}
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				await rm(tempRoot, { recursive: true, force: true });
+			} catch (error) {
+				cleanupError = error instanceof Error ? error : new Error(String(error));
+			}
+			if (cleanupError) throw new Error("Official direct Computer Use broker cleanup failed", { cause: cleanupError });
+			if (fatalError || modelTurnsStarted !== 0) throw fatalError ?? new BrokerVerificationError("Model-turn activity was observed during broker teardown");
+		})();
+		return closePromise;
 	};
 
 	try {
@@ -560,24 +595,15 @@ export async function callOfficialDirectTool(
 		});
 		processClosed = new Promise((resolve) => proc!.once("close", () => resolve()));
 		if (proc.pid) options.onSpawn?.(proc.pid);
-		proc.stdin.on("error", (error: NodeJS.ErrnoException) => {
-			if (error.code !== "EPIPE") fail(error);
-		});
+		proc.stdin.on("error", (error: NodeJS.ErrnoException) => { if (error.code !== "EPIPE") fail(error); });
 		proc.stderr.setEncoding("utf8");
-		proc.stderr.on("data", (chunk: string) => {
-			if (stderr.length < 16_384) stderr += chunk.slice(0, 16_384 - stderr.length);
-		});
+		proc.stderr.on("data", (chunk: string) => { if (stderr.length < 16_384) stderr += chunk.slice(0, 16_384 - stderr.length); });
 		proc.once("error", (error) => fail(error));
-		proc.once("close", (code) => {
-			if (pending.size > 0) fail(new Error(`Official app-server exited before completing the request (${code ?? "unknown"})`));
-		});
+		proc.once("close", (code) => { if (!closed && pending.size > 0) fail(new Error(`Official app-server exited before completing the request (${code ?? "unknown"})`)); });
 
 		const processProtocolLine = (line: string): void => {
 			let message: any;
-			try { message = JSON.parse(line); } catch {
-				fail(new Error("Official app-server emitted malformed JSONL"));
-				return;
-			}
+			try { message = JSON.parse(line); } catch { fail(new Error("Official app-server emitted malformed JSONL")); return; }
 			if (typeof message?.method === "string" && (message.method.startsWith("turn/") || message.method.startsWith("item/"))) {
 				modelTurnsStarted += 1;
 				fail(new Error("Official app-server unexpectedly emitted model-turn activity during direct dispatch"));
@@ -599,28 +625,22 @@ export async function callOfficialDirectTool(
 						send({ id: message.id, error: { code: -32601, message: "Unsupported server request" } });
 						return;
 					}
-					elicitationRequests += 1;
+					currentElicitationCount += 1;
 					const requestParams = message.params && typeof message.params === "object" && !Array.isArray(message.params)
-						? message.params as DirectBrokerElicitationRequest
-						: {};
+						? message.params as DirectBrokerElicitationRequest : {};
 					void (async () => {
 						let response: DirectBrokerElicitationResponse = { action: "cancel" };
-						if (options.onElicitation) {
+						if (currentElicitation) {
 							try {
-								const candidate = await options.onElicitation(requestParams);
+								const candidate = await currentElicitation(requestParams);
 								if (candidate && ["accept", "decline", "cancel"].includes(candidate.action)) response = candidate;
-							} catch {
-								response = { action: "cancel" };
-							}
+							} catch { response = { action: "cancel" }; }
 						}
-						if (fatalError || !proc?.stdin.writable) return;
+						if (fatalError || closed || !proc?.stdin.writable) return;
 						send({ id: message.id, result: response });
 					})().catch((error) => fail(error instanceof Error ? error : new Error(String(error))));
-					return;
 				}
-			} catch (error) {
-				fail(error instanceof Error ? error : new Error(String(error)));
-			}
+			} catch (error) { fail(error instanceof Error ? error : new Error(String(error))); }
 		};
 		let stdoutBuffer = "";
 		proc.stdout.setEncoding("utf8");
@@ -631,123 +651,129 @@ export async function callOfficialDirectTool(
 				const end = newline === -1 ? chunk.length : newline;
 				const segment = chunk.slice(offset, end);
 				if (Buffer.byteLength(stdoutBuffer, "utf8") + Buffer.byteLength(segment, "utf8") > MAX_PROTOCOL_LINE_BYTES) {
-					fail(new Error("Official app-server protocol line exceeded the 8MB safety bound"));
-					return;
+					fail(new Error("Official app-server protocol line exceeded the 8MB safety bound")); return;
 				}
-				if (newline === -1) {
-					stdoutBuffer += segment;
-					return;
-				}
+				if (newline === -1) { stdoutBuffer += segment; return; }
 				const line = stdoutBuffer + segment;
 				stdoutBuffer = "";
 				if (line.length > 0) processProtocolLine(line);
 				offset = newline + 1;
 			}
 		});
-		proc.stdout.on("end", () => {
-			if (stdoutBuffer.length > 0) processProtocolLine(stdoutBuffer);
-			stdoutBuffer = "";
-		});
+		proc.stdout.on("end", () => { if (stdoutBuffer.length > 0) processProtocolLine(stdoutBuffer); stdoutBuffer = ""; });
 
-		if (options.signal) {
-			abortHandler = () => {
-				fail(new Error("Direct Computer Use request cancelled"));
-			};
-			if (options.signal.aborted) abortHandler();
-			else options.signal.addEventListener("abort", abortHandler, { once: true });
-		}
-		if (fatalError) throw fatalError;
-		await request(
-			"initialize",
-			{
-				clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.1" },
-				capabilities: { mcpServerOpenaiFormElicitation: options.supportsOpenAiFormElicitation === true && options.onElicitation !== undefined },
-			},
-			15_000,
-		);
+		await request("initialize", {
+			clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.2" },
+			capabilities: { mcpServerOpenaiFormElicitation: options.supportsOpenAiFormElicitation === true },
+		}, 15_000);
 		send({ method: "initialized" });
-		// Codex Full access requires both values: with `never` plus a restricted sandbox,
-		// core declines the signed service's app approval instead of prompting or accepting it.
-		const started = (await request(
-			"thread/start",
-			{ cwd: workDir, approvalPolicy: "never", sandbox: "danger-full-access", ephemeral: true, serviceName: "pi_direct_computer_use" },
-			30_000,
-		)) as any;
+		const started = (await request("thread/start", {
+			cwd: workDir, approvalPolicy: "never", sandbox: "danger-full-access", ephemeral: true, serviceName: "pi_direct_computer_use",
+		}, 30_000)) as any;
 		const thread = started?.thread;
-		const threadId = thread?.id;
-		if (
-			typeof threadId !== "string"
-			|| thread.ephemeral !== true
-			|| !Object.prototype.hasOwnProperty.call(thread, "path")
-			|| thread.path !== null
-			|| !Array.isArray(thread.turns)
-			|| thread.turns.length !== 0
-		) {
+		threadId = thread?.id;
+		if (typeof threadId !== "string" || thread.ephemeral !== true || !Object.prototype.hasOwnProperty.call(thread, "path") || thread.path !== null || !Array.isArray(thread.turns) || thread.turns.length !== 0) {
 			throw new BrokerVerificationError("App-server did not attest an empty pathless ephemeral runtime context");
 		}
 		ephemeralThread = true;
-		const inventory = await request(
-			"mcpServerStatus/list",
-			{ threadId, detail: "toolsAndAuthOnly" },
-			45_000,
-		);
-		validateInventory(inventory);
-		const raw = await request(
-			"mcpServer/tool/call",
-			{ threadId, server: "computer-use", tool: method, arguments: args },
-			options.timeoutMs ?? 120_000,
-		);
-		directCalls = 1;
-		if (modelTurnsStarted !== 0) throw new BrokerVerificationError("Model-turn activity was observed during direct dispatch");
-		const result = validateResult(raw);
-		finalResult = {
-			...result,
-			brokerVersion: verification.brokerVersion,
-			clientBuild: verification.clientBuild,
-			durationMs: Date.now() - startedAt,
-			elicitationRequests,
-			modelTurnsStarted: 0,
-			ephemeralThread: true,
-			brokerCleanupVerified: true,
-		};
 	} catch (error) {
 		const base = error instanceof Error ? error : new Error(String(error));
-		primaryError = /authentication|bearer|token/i.test(`${base.message}\n${stderr}`)
-			? new Error("Official direct Computer Use broker reported an authentication failure")
-			: base;
-	} finally {
-		if (abortHandler && options.signal) options.signal.removeEventListener("abort", abortHandler);
-		rejectAll(new Error("Official app-server closed"));
-		try {
-			await ensureTerminated();
-			if (processClosed) {
-				await new Promise<void>((resolve, reject) => {
-					const timer = setTimeout(() => reject(new Error("Official app-server stdio did not close")), 1_000);
-					processClosed!.then(() => {
-						clearTimeout(timer);
-						resolve();
-					});
-				});
+		const primary = /authentication|bearer|token/i.test(`${base.message}\n${stderr}`)
+			? new Error("Official direct Computer Use broker reported an authentication failure") : base;
+		try { await close(); }
+		catch (closeError) {
+			const closeFailure = closeError instanceof Error ? closeError : new Error(String(closeError));
+			if (closeFailure.message === "Official direct Computer Use broker cleanup failed") {
+				throw new DirectBrokerCallError(closeFailure.message, false, primary);
 			}
-			await new Promise<void>((resolve) => setImmediate(resolve));
-			if (fatalError || modelTurnsStarted !== 0) {
-				primaryError = fatalError ?? new BrokerVerificationError("Model-turn activity was observed during broker teardown");
-			}
-			await rm(tempRoot, { recursive: true, force: true });
-			cleanupVerified = true;
-		} catch (cleanupError) {
-			primaryError = new Error("Official direct Computer Use broker cleanup failed", { cause: cleanupError });
 		}
+		throw new DirectBrokerCallError(primary.message, true, primary, { modelTurnsStarted, ephemeralThread, brokerVersion: verification.brokerVersion, clientBuild: verification.clientBuild });
 	}
-	const failureEvidence = {
-		directCalls,
-		modelTurnsStarted,
-		ephemeralThread,
-		elicitationRequests,
-		brokerVersion: verification.brokerVersion,
-		clientBuild: verification.clientBuild,
+
+	return {
+		async call(method, args, callOptions = {}) {
+			if (closed) throw new DirectBrokerCallError("Official direct Computer Use session is closed", true);
+			if (callActive) throw new DirectBrokerCallError("Official direct Computer Use session does not allow concurrent calls", false);
+			callActive = true;
+			currentElicitation = callOptions.onElicitation;
+			currentElicitationCount = 0;
+			const startedAt = Date.now();
+			let directCalls = 0;
+			let abortHandler: (() => void) | undefined;
+			try {
+				if (callOptions.signal) {
+					abortHandler = () => fail(new Error("Direct Computer Use request cancelled"));
+					if (callOptions.signal.aborted) abortHandler();
+					else callOptions.signal.addEventListener("abort", abortHandler, { once: true });
+				}
+				if (fatalError) throw fatalError;
+				const inventory = await request("mcpServerStatus/list", { threadId, detail: "toolsAndAuthOnly" }, 45_000);
+				validateInventory(inventory);
+				const raw = await request("mcpServer/tool/call", { threadId, server: "computer-use", tool: method, arguments: args }, callOptions.timeoutMs ?? 120_000);
+				directCalls = 1;
+				if (modelTurnsStarted !== 0) throw new BrokerVerificationError("Model-turn activity was observed during direct dispatch");
+				const result = validateResult(raw);
+				return {
+					...result,
+					brokerVersion: verification.brokerVersion,
+					clientBuild: verification.clientBuild,
+					durationMs: Date.now() - startedAt,
+					elicitationRequests: currentElicitationCount,
+					modelTurnsStarted: 0,
+					ephemeralThread: true,
+					brokerCleanupVerified: false,
+				};
+			} catch (error) {
+				const base = error instanceof Error ? error : new Error(String(error));
+				const primary = /authentication|bearer|token/i.test(`${base.message}\n${stderr}`)
+					? new Error("Official direct Computer Use broker reported an authentication failure") : base;
+				throw new DirectBrokerCallError(primary.message, false, primary, {
+					directCalls, modelTurnsStarted, ephemeralThread, elicitationRequests: currentElicitationCount,
+					brokerVersion: verification.brokerVersion, clientBuild: verification.clientBuild,
+				});
+			} finally {
+				if (abortHandler && callOptions.signal) callOptions.signal.removeEventListener("abort", abortHandler);
+				currentElicitation = undefined;
+				callActive = false;
+			}
+		},
+		close,
 	};
-	if (primaryError) throw new DirectBrokerCallError(primaryError.message, cleanupVerified, primaryError, failureEvidence);
-	if (!finalResult) throw new DirectBrokerCallError("Official direct Computer Use ended without a result", cleanupVerified, undefined, failureEvidence);
-	return finalResult;
+}
+
+export async function callOfficialDirectTool(
+	method: DirectMethod,
+	args: DirectToolArguments,
+	options: DirectBrokerOptions = {},
+): Promise<DirectBrokerResult> {
+	let session: OfficialDirectToolSession | undefined;
+	let result: DirectBrokerResult | undefined;
+	let failure: unknown;
+	try {
+		session = await createOfficialDirectToolSession(options);
+		result = await session.call(method, args, options);
+	} catch (error) {
+		failure = error;
+	}
+	let cleanupVerified = failure instanceof DirectBrokerCallError ? failure.cleanupVerified : false;
+	try {
+		if (session) {
+			await session.close();
+			cleanupVerified = true;
+		}
+	} catch (cleanupError) {
+		const closeFailure = cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+		if (closeFailure.message !== "Official direct Computer Use broker cleanup failed") {
+			throw new DirectBrokerCallError(closeFailure.message, true, closeFailure, failure instanceof DirectBrokerCallError ? failure : {});
+		}
+		throw new DirectBrokerCallError(closeFailure.message, false, closeFailure, failure instanceof DirectBrokerCallError ? failure : {});
+	}
+	if (failure) {
+		if (failure instanceof DirectBrokerCallError) {
+			throw new DirectBrokerCallError(failure.message, cleanupVerified, failure, failure);
+		}
+		throw failure;
+	}
+	if (!result) throw new DirectBrokerCallError("Official direct Computer Use ended without a result", cleanupVerified);
+	return { ...result, brokerCleanupVerified: true };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,7 @@ import {
 	OFFICIAL_TOOL_METADATA,
 } from "./tools.ts";
 
-const version = "0.3.1";
+const version = "0.3.2";
 
 async function handleCli(): Promise<boolean> {
 	const args = process.argv.slice(2);

--- a/test/direct-broker.test.ts
+++ b/test/direct-broker.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { buildDirectAppServerArgs, callOfficialDirectTool } from "../src/direct-broker.ts";
+import { buildDirectAppServerArgs, callOfficialDirectTool, createOfficialDirectToolSession } from "../src/direct-broker.ts";
 import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS } from "../src/tools.ts";
 
 async function makeFake(root: string): Promise<{ script: string; log: string }> {
@@ -18,7 +18,7 @@ import { createInterface } from "node:readline";
 const log=${JSON.stringify(log)}; const mode=process.argv[2]||"ok"; const inventory=${JSON.stringify(inventory)};
 const send=x=>process.stdout.write(JSON.stringify(x)+"\\n");
 const rl=createInterface({input:process.stdin});
-let pendingTool;
+let pendingTool; let activeApp;
 if(mode==="child-hang"||mode==="orphan-exit"){const child=spawn(process.execPath,["-e","process.on('SIGTERM',()=>{});setInterval(()=>{},1000)"],{detached:true,stdio:"ignore"});child.unref();appendFileSync(log,JSON.stringify({childPid:child.pid})+"\\n");if(mode==="orphan-exit")process.exit(0);}
 rl.on("line",line=>{const m=JSON.parse(line); appendFileSync(log,JSON.stringify({method:m.method,id:m.id,params:m.params,result:m.result,codexHome:process.env.CODEX_HOME,home:process.env.HOME,tmpdir:process.env.TMPDIR,hasOpenAIKey:Boolean(process.env.OPENAI_API_KEY)})+"\\n");
  if(m.method==="initialize"){if(mode==="oversized-line"){process.stdout.write("x".repeat(${8 * 1024 * 1024 + 1}));return;} return send({id:m.id,result:{userAgent:"fake",platformFamily:"unix",platformOs:"macos"}});}
@@ -27,6 +27,11 @@ rl.on("line",line=>{const m=JSON.parse(line); appendFileSync(log,JSON.stringify(
  if(m.method==="mcpServerStatus/list"){const tools=JSON.parse(JSON.stringify(inventory)); if(mode==="schema-drift")tools.list_apps.inputSchema.properties={drift:{type:"string"}}; send({id:m.id,result:{data:[{name:"computer-use",tools}]}});if(mode==="close-before-tool"){process.stdin.destroy();setTimeout(()=>process.exit(0),100);}return;}
  if(m.method==="mcpServer/tool/call"){
    if(mode==="hang"||mode==="child-hang") return;
+   if(mode==="lease"){
+     if(m.params.tool==="get_app_state") activeApp=m.params.arguments.app;
+     else if(activeApp!==m.params.arguments.app) return send({id:m.id,result:{content:[{type:"text",text:"Computer Use is not active"}],isError:true}});
+     return send({id:m.id,result:{content:[{type:"text",text:m.params.tool+":"+activeApp}],isError:false}});
+   }
    if(mode==="elicit"){pendingTool=m.id; return send({id:"elicitation-1",method:"mcpServer/elicitation/request",params:{mode:"form",message:"Choose access",serverName:"computer-use",requestedSchema:{type:"object",properties:{choice:{type:"string",enum:["allow","deny"]}},required:["choice"]},_meta:{source:"official-test"}}});}
    if(mode==="late-model-event"){send({id:m.id,result:{content:[{type:"text",text:"direct-ok"}],isError:false}});return send({method:"turn/started",params:{late:true}});}
    return send({id:m.id,result:{content:[{type:"text",text:"direct-ok"}],isError:false}});
@@ -83,6 +88,24 @@ test("direct broker uses only zero-turn app-server MCP methods and an isolated c
 	}
 });
 
+test("one broker session preserves the official active-app lease across inspection and action", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "direct-broker-lease-test."));
+	try {
+		const { script, log } = await makeFake(root);
+		const session = await createOfficialDirectToolSession(options(script, "lease"));
+		try {
+			const state = await session.call("get_app_state", { app: "com.google.Chrome" });
+			const action = await session.call("press_key", { app: "com.google.Chrome", key: "Escape" });
+			assert.equal(state.content[0].text, "get_app_state:com.google.Chrome");
+			assert.equal(action.content[0].text, "press_key:com.google.Chrome");
+		} finally { await session.close(); }
+		const records = (await readFile(log, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+		assert.equal(records.filter((item) => item.method === "initialize").length, 1);
+		assert.equal(records.filter((item) => item.method === "thread/start").length, 1);
+		assert.equal(records.filter((item) => item.method === "mcpServer/tool/call").length, 2);
+	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
 test("direct broker rejects upstream schema drift before tool dispatch", async () => {
 	const root = await mkdtemp(path.join(os.tmpdir(), "direct-broker-drift-test."));
 	try {
@@ -93,6 +116,22 @@ test("direct broker rejects upstream schema drift before tool dispatch", async (
 		);
 		const methods = (await readFile(log, "utf8")).trim().split("\n").map((line) => JSON.parse(line).method);
 		assert.equal(methods.includes("mcpServer/tool/call"), false);
+	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("one-shot wrapper preserves a setup-phase cleanup failure", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "direct-broker-setup-cleanup-test."));
+	try {
+		const { script } = await makeFake(root);
+		let observed: unknown;
+		try {
+			await callOfficialDirectTool("list_apps", {}, {
+				...options(script, "schema-drift"),
+				processEnumeratorCommand: path.join(root, "missing-enumerator"),
+			});
+		} catch (error) { observed = error; }
+		assert.match((observed as Error)?.message ?? "", /cleanup failed/);
+		assert.equal((observed as any)?.cleanupVerified, false);
 	} finally { await rm(root, { recursive: true, force: true }); }
 });
 

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { EXPECTED_OFFICIAL_INPUT_SCHEMAS, OFFICIAL_METHODS, OFFICIAL_TOOL_METADATA } from "../src/tools.ts";
 
-test("Pi adapter registers all ten tools through one no-permissions path with progressive disclosure", async () => {
+test("Pi adapter registers all ten tools through one direct no-permissions session path", async () => {
 	const source = await readFile("integrations/pi/index.ts", "utf8");
 	assert.match(source, /const piName = `computer_use_\$\{method\}`/);
 	for (const method of OFFICIAL_METHODS) assert.match(source, new RegExp(`\\b${method}: Type\\.Object`));
@@ -37,8 +39,10 @@ test("Pi adapter registers all ten tools through one no-permissions path with pr
 	assert.match(source, /onElicitation: \(request\) => handleOfficialElicitation/);
 	assert.match(source, /supportsOpenAiFormElicitation: true/);
 	assert.match(source, /Call computer_use_get_app_state once per assistant turn before interacting with an app/);
-	assert.match(source, /if \(method === "get_app_state"\) activateInteractionTools\(pi\)/);
+	assert.match(source, /new PiDirectSessionExecutor\(\)/);
+	assert.match(source, /sessionExecutor\.execute/);
 	assert.match(source, /pi\.on\("session_start", \(\) => setInitialComputerUseTools\(pi\)\)/);
+	assert.match(source, /pi\.on\("session_shutdown", \(\) => sessionExecutor\.close\(\)\)/);
 });
 
 test("Pi surfaces an official form elicitation and returns the user's structured response", async () => {
@@ -161,19 +165,68 @@ test("Pi runtime registration exposes the exact official contract for all ten to
 
 	handlers.get("session_start")!();
 	assert.ok(active.has("read"), "preserves tools owned by Pi and other extensions");
-	for (const name of INSPECTION_TOOL_NAMES) assert.ok(active.has(name));
-	for (const name of INTERACTION_TOOL_NAMES) assert.ok(!active.has(name));
+	for (const name of [...INSPECTION_TOOL_NAMES, ...INTERACTION_TOOL_NAMES]) {
+		assert.ok(active.has(name), `activates direct tool ${name}`);
+	}
 });
 
-test("Pi interaction activation is purely additive", async () => {
-	const { activateInteractionTools, INTERACTION_TOOL_NAMES } = await import("../integrations/pi/index.ts");
-	const before = ["read", "computer_use_list_apps", "computer_use_get_app_state", "another_extension_tool"];
-	let after: string[] = [];
-	activateInteractionTools({
-		getActiveTools: () => [...before],
-		setActiveTools: (names: string[]) => { after = names; },
+test("Pi broker setup failures stay inside the audited direct-service path", async () => {
+	const { PiDirectSessionExecutor } = await import("../integrations/pi/index.ts");
+	const root = await mkdtemp(path.join(os.tmpdir(), "pi-direct-setup-audit-test."));
+	try {
+		const executor = new PiDirectSessionExecutor({
+			createSession: async () => { throw new Error("verified broker setup failed"); },
+		} as any);
+		await assert.rejects(executor.execute("get_app_state", { app: "TextEdit" }, {
+			stateRoot: root,
+			resolveIdentity: () => ({ bundleId: "com.apple.TextEdit", leaseId: "com.apple.textedit", verifiedSystemDictionary: false }),
+			frontmost: () => "com.google.Chrome",
+			frontmostAsync: async () => "com.google.Chrome",
+			watchFocus: async () => ({ healthy: () => true, becameFrontmost: () => false, stop: async () => undefined }),
+			acquireLock: async (_state: string, app: string, runId: string) => ({
+				path: "test", owner: { runId, pid: process.pid, app, startedAt: new Date().toISOString() }, release: async () => undefined,
+			}),
+		} as any), /verified broker setup failed/);
+		const audit = JSON.parse((await readFile(path.join(root, "audit", "direct-computer-use.jsonl"), "utf8")).trim());
+		assert.equal(audit.outcome, "broker_failed");
+		assert.equal(audit.brokerCleanupVerified, false);
+		assert.equal(audit.directCalls, 0);
+	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("Pi direct executor reuses one signed client session for get_app_state and the following action", async () => {
+	const { PiDirectSessionExecutor } = await import("../integrations/pi/index.ts");
+	const calls: Array<{ session: number; method: string }> = [];
+	let sessionsCreated = 0;
+	let sessionsClosed = 0;
+	const executor = new PiDirectSessionExecutor({
+		createSession: async () => {
+			const session = ++sessionsCreated;
+			return {
+				async call(method: string) {
+					calls.push({ session, method });
+					return {
+						content: [{ type: "text", text: method }], isError: false,
+						brokerVersion: "test", clientBuild: "test", durationMs: 1,
+						elicitationRequests: 0, modelTurnsStarted: 0, ephemeralThread: true,
+						brokerCleanupVerified: false,
+					};
+				},
+				async close() { sessionsClosed += 1; },
+			};
+		},
+		executeTool: async (request: any, dependencies: any) => {
+			const broker = await dependencies.callTool(request.method, request.arguments, {});
+			return { ok: true, isError: false, content: broker.content, details: {} };
+		},
 	} as any);
-	for (const name of before) assert.ok(after.includes(name), `preserves active tool ${name}`);
-	for (const name of INTERACTION_TOOL_NAMES) assert.ok(after.includes(name), `activates ${name}`);
-	assert.equal(new Set(after).size, after.length);
+	await executor.execute("get_app_state", { app: "com.google.Chrome" }, {});
+	assert.equal(sessionsClosed, 0, "inspection retains the active-app client lease");
+	await executor.execute("press_key", { app: "com.google.Chrome", key: "ESC" }, {});
+	assert.deepEqual(calls, [
+		{ session: 1, method: "get_app_state" },
+		{ session: 1, method: "press_key" },
+	]);
+	assert.equal(sessionsCreated, 1);
+	assert.equal(sessionsClosed, 1, "the paired action closes the retained signed session");
 });


### PR DESCRIPTION
## Summary

- activate all ten direct Pi Computer Use tools together in fresh sessions
- retain one verified app-server runtime, ephemeral thread, and signed Computer Use client across `get_app_state` and the following direct action
- close and verify the retained process tree after the paired action, replacement inspection, or Pi session shutdown
- keep one-shot MCP behavior while preserving setup-failure cleanup evidence
- prepare patch release 0.3.2 and update integration, architecture, security, proof, and migration documentation

Closes #10

## Security boundary

The change retains strict canonical-path and code-signature verification, OpenAI Team ID `2DC432GLL2`, the exact ten-tool inventory and schemas before every dispatch, zero-turn/pathless-ephemeral attestation, isolated credential-free broker state, canonical app identity, per-app kernel locking, focus telemetry, bounded protocol/results, fail-closed process cleanup, and metadata-only audit logging.

No unsigned or arbitrary fallback, re-signing, injected control, private protocol access, TCC automation, model turn, provider-boundary bypass, wrapper permission branch, or foreground automation was added.

## Validation

- `npm run check`: pass
- `npm run check:pi`: pass
- `npm test`: 68/68 pass
- `npm run build`: pass
- `npm pack --dry-run --json --ignore-scripts`: pass (40 files)
- official signed helper inventory/schema test: pass against installed component build 1000502
- independent exact-head review of `ec9dbc72573e0c4e07d83b9fbafa3642bba63acf`: no blocking findings

`npm audit --omit=dev` reports the existing `@hono/node-server` Windows-only `serve-static` advisory through MCP SDK 1.29.0. This package is Darwin-only and stdio-only; no compatible upstream dependency fix is currently available.

## Live acceptance status

The fresh signed-service action smoke remains pending because the official service returned `NSOSStatusErrorDomain Code=-609 "connectionInvalid"` on the required initial `get_app_state`. No interaction was attempted after that mandated stop condition. Merge and release remain gated on a healthy unlocked-session `get_app_state` → harmless `ESC` run through the exact installed package head.
