### PR TITLE
docs: clarify thin-wrapper agent intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Repository agent guidance
+
+## Product intent
+
+This repository exposes the official signed macOS Computer Use tools to Pi and MCP clients. It is a thin transport adapter. The calling agent selects the official method and arguments. OpenAI Codex and macOS control tool behavior, app access, and platform permissions.
+
+Preserve the official capability surface:
+
+- do not add wrapper permission prompts, app or intent allowlists, action gates, risk classifiers, content inspection, alternate safe modes, or other policy that narrows the official tools
+- do not add defence-in-depth because a hypothetical safeguard is possible
+- add wrapper logic only when the transport, official component compatibility, zero-model-turn architecture, process lifecycle, or a concrete user-visible bug requires it
+- prefer removing accidental wrapper policy when Thomas explicitly approves that contract change
+
+## Existing wrapper behavior
+
+The earlier background-computer-use wrapper introduced canonical app resolution, same-app locking, focus completion telemetry, and metadata-only audit. The current release retains these behaviors. They do not provide independent authorization or sandbox boundaries. Their presence does not justify further hardening.
+
+Fix concrete compatibility failures in these paths when needed. Do not broaden them based only on synthetic or adversarial possibilities. A maintainer must explicitly approve their removal or material simplification because this changes the package contract.
+
+Signature and Team ID verification, the signed responsible-process path, schema compatibility checks, zero-turn attestation, isolated temporary state, and process cleanup support the official transport and architecture. Keep them within that role. Do not turn them into a general security framework.
+
+## Review standard
+
+Review for material user outcomes and realistic regressions in the supported production path.
+
+- only report a blocking finding when it is reachable under normal supported inputs, or when evidence shows realistic exploitability and material effect
+- distinguish correctness and compatibility bugs from optional robustness or defence-in-depth
+- do not block a focused compatibility fix on unrelated hardening, speculative malformed input, or a stronger wrapper boundary
+- validate the exact diff and relevant end-to-end path
+- do not infer failure from a synthetic parser case when the producing system cannot realistically emit it
+
+A request to review a pull request authorizes local inspection and a report to the requester. It does not authorize a GitHub post. Before submitting a review, comment, reaction, issue, or suggested change, show Thomas the exact proposed text and get his explicit approval to post it.
+
+## Development
+
+Use the documented verification chain:
+
+```bash
+npm ci
+npm run check
+npm run check:pi
+npm test
+npm run build
+```
+
+Use benign real applications for live acceptance. Keep changes tied to the requested outcome. Preserve the official ten-tool contract and no-permissions behavior unless Thomas explicitly asks to change them.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,14 @@
 
 Code Mode remains outside this package. See [ADR 0001: Keep Code Mode in a standalone MCP process](docs/adr/0001-standalone-code-mode-mcp.md).
 
+## Design intent
+
+This package is a thin transport adapter to the official signed Computer Use tools. It has no independent policy or security role. Codex and macOS remain authoritative for tool behavior, access decisions, and platform controls.
+
+Preserve the official capability surface. Add adapter code only when the transport, zero-model-turn architecture, component compatibility, or process lifecycle requires it.
+
+Canonical app resolution, same-app locking, focus completion telemetry, and metadata-only audit came from the earlier background-computer-use wrapper. The current release retains them for compatibility. They do not provide extra authorization or sandbox boundaries. This inventory does not justify extending them. A maintainer must explicitly approve their removal or material simplification.
+
 ## Official API evidence
 
 The architecture uses public source and the installed signed binaries; it does not speak a private Computer Use socket protocol.
@@ -90,40 +98,42 @@ codex mcp-server model tools
 nested prompts or result summaries
 ```
 
-## Restriction inventory
+## Current adapter inventory
 
-| Released wrapper restriction | Classification | Direct design |
+| Mechanism or former restriction | Role in the direct design | Current treatment |
 |---|---|---|
-| Reviewed ChatGPT/Codex/client paths | **official-required** | current per-user installed-component contract plus exact legacy plugin layout; canonicalized and verified |
-| Strict signatures and OpenAI Team ID | **security-essential** | retained |
-| Signed-parent/responsible-process chain | **official-required** | retained through signed app-server |
-| Private Sky socket/native-pipe access | **unsupported/private** | prohibited |
-| Nested Codex model and prompt | **compatibility-only** | removed |
-| Model selection and reasoning effort | **compatibility-only** | removed; dummy unreachable provider prevents model transport |
-| Responses websocket prewarm on empty thread | **accidental app-server behavior** | disabled with non-websocket dummy provider |
-| Plugin/remote-control startup networking | **accidental app-server behavior** | corresponding features disabled |
-| Model-written multi-step task plan | **compatibility-only** | removed |
-| Model result schema/summary | **compatibility-only** | removed |
-| Streamed model-event target/method validation | **compatibility-only** | replaced by pre-dispatch typed call validation |
-| Per-operation tool allowlists and call budgets | **compatibility-only** | one typed method per direct request |
-| Task text, cleanup instructions, required-capabilities fields | **compatibility-only** | removed |
-| Dictionary-only special policy | **accidental** | removed |
-| Wrapper app/intent allowlists in full mode | **accidental** | absent |
-| Safe/full wrapper modes | **compatibility-only** | removed; one durable no-permissions interface exposes all ten methods |
-| Wrapper approval prompts/configuration | **compatibility-only** | removed; no command, config, environment, or per-call selector remains |
-| Official first-party app access | **official-required** | official Codex Full access auto-accepts normal empty-schema app approval elicitations; any elicitation app-server emits is forwarded unchanged |
-| macOS TCC | **official-required** | retained; never modified |
-| Exact ten-tool inventory/schema | **security-essential** | retained and checked before each call |
-| Canonical bundle identity | **security-essential** | retained before targeted dispatch |
-| Same-app kernel lock | **security-essential** | retained in one fixed per-user namespace shared across Pi/MCP state roots |
-| Automatic background app launch | **accidental** | removed; the official tool owns app behavior |
-| Global focus watcher and final sample | **security-essential detection** | retained |
-| Timeout/cancellation process-tree termination | **security-essential** | retained with strict enumeration, freeze, kill, stdio-close, and exit verification |
-| Temporary broker-session cleanup | **security-essential** | retained with isolated `CODEX_HOME`; Pi closes after the inspection-action pair, replacement inspection, or session shutdown |
-| Codex token usage accounting | **compatibility-only** | removed; no model turn exists |
-| Content-safe private audit | **security-essential** | retained with direct-call fields |
-| Full-result spill files | **unsafe/accidental** | prohibited; truncation is in-memory only |
-| Browser-host integration | **out of scope** | unchanged |
+| Reviewed ChatGPT/Codex/client paths | official transport compatibility | current per-user installed-component contract plus exact legacy plugin layout; canonicalized and verified |
+| Strict signatures and OpenAI Team ID | official component verification | retained to verify the selected signed transport components |
+| Signed-parent/responsible-process chain | official transport requirement | retained through signed app-server |
+| Private Sky socket/native-pipe access | unsupported/private route | prohibited |
+| Nested Codex model and prompt | former compatibility layer | removed |
+| Model selection and reasoning effort | former compatibility layer | removed; dummy unreachable provider prevents model transport |
+| Responses websocket prewarm on empty thread | accidental app-server behavior | disabled with non-websocket dummy provider |
+| Plugin/remote-control startup networking | accidental app-server behavior | corresponding features disabled |
+| Model-written multi-step task plan | former compatibility layer | removed |
+| Model result schema/summary | former compatibility layer | removed |
+| Streamed model-event target/method validation | former compatibility layer | replaced by pre-dispatch typed call validation |
+| Per-operation tool allowlists and call budgets | former wrapper policy | removed; one typed method per direct request |
+| Task text, cleanup instructions, required-capabilities fields | former compatibility layer | removed |
+| Dictionary-only special policy | former wrapper policy | removed |
+| Wrapper app/intent allowlists in full mode | former wrapper policy | absent |
+| Safe/full wrapper modes | former wrapper policy | removed; one durable no-permissions interface exposes all ten methods |
+| Wrapper approval prompts/configuration | former wrapper policy | removed; no command, config, environment, or per-call selector remains |
+| Official first-party app access | official Codex control | official Codex Full access auto-accepts normal empty-schema app approval elicitations; any elicitation app-server emits is forwarded unchanged |
+| macOS TCC | official platform control | retained; never modified |
+| Exact ten-tool inventory/schema | protocol compatibility check | retained and checked before each call |
+| Canonical bundle identity | legacy wrapper behavior | retained for the current release contract; not an independent authorization boundary |
+| Same-app kernel lock | legacy wrapper coordination | retained in one fixed per-user namespace shared across Pi/MCP state roots |
+| Automatic background app launch | accidental wrapper behavior | removed; the official tool owns app behavior |
+| Global focus watcher and final sample | legacy completion telemetry | retained for the current release contract; not a preventive sandbox |
+| Timeout/cancellation process-tree termination | operational lifecycle | retained with strict enumeration, freeze, kill, stdio-close, and exit verification |
+| Temporary broker-session cleanup | operational lifecycle | retained with isolated `CODEX_HOME`; Pi closes after the inspection-action pair, replacement inspection, or session shutdown |
+| Codex token usage accounting | former compatibility layer | removed; no model turn exists |
+| Content-safe private audit | legacy observability behavior | retained with direct-call fields; not an authorization mechanism |
+| Full-result spill files | output hygiene | prohibited; truncation is in-memory only |
+| Browser-host integration | out of scope | unchanged |
+
+These roles explain the current code. They do not authorize new safeguards. Only propose hardening for a concrete, realistically reachable failure in the supported path.
 
 ## No-permissions and elicitation boundary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome, especially compatibility fixes, direct-protocol tests, adversarial boundary tests, and clearer host diagnostics.
+Contributions are welcome, especially compatibility fixes, direct-protocol tests, realistic regression coverage, and clearer host diagnostics.
 
 ## Setup
 
@@ -20,12 +20,13 @@ Development and live acceptance require macOS and the official ChatGPT Computer 
 - Do not add a nested model, action planner, prompt, subagent, or model-written result summary to direct dispatch.
 - Do not use private pipes/sockets, credential extraction, app injection, re-signing, sender impersonation, TCC automation, or automatic approval acceptance.
 - Keep app-server in a credential-free isolated `CODEX_HOME` with only official Computer Use configured.
-- Add a regression test for every protocol, policy, focus, cleanup, or audit fix.
+- Add a regression test for each concrete protocol, compatibility, lifecycle, or current-behavior fix.
 - Never log or persist arguments, typed values, screenshots, app-state/result content, elicitation contents, prompts, credentials, or tokens.
-- Treat focus checks as post-action detection rather than preventive isolation.
+- Do not add wrapper-side permission policy, risk classification, allowlists, gates, or speculative defence-in-depth on top of official Codex and macOS controls.
+- Treat current focus checks as legacy post-action completion telemetry, not preventive isolation or a precedent for further hardening.
 - Document reviewed ChatGPT component paths, launcher contracts, and upstream schema/API assumptions.
 - Include strict core/Pi type checks, tests, build, audit, package inspection, and real-app acceptance evidence.
-- Obtain independent exact-head review for security-boundary changes.
+- Review material transport or published-behavior changes at the exact head, and keep findings tied to realistic supported paths.
 
 Repository/package renaming, merge, npm publication, and GitHub release require separate maintainer approval.
 

--- a/PROOF.md
+++ b/PROOF.md
@@ -1,6 +1,6 @@
 # Direct architecture proof and acceptance record
 
-This file records evidence for the 0.2 direct-tool branch. It is not a compatibility promise for future ChatGPT versions.
+This file records evidence for the 0.2 direct-tool branch. It does not promise compatibility with future ChatGPT versions or authorize more wrapper safeguards. Historical proof for focus telemetry, locking, cleanup, and audit records released behavior. It does not give the wrapper an independent policy or security role.
 
 ## Supported direct path
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ As the official contract specifies, Pi—not a nested planner—calls `computer_
 
 The app-server runtime uses the official Full access combination: `approvalPolicy: "never"` and `sandbox: "danger-full-access"`. In the pinned Codex host, that maps to a disabled permission profile and automatically accepts empty-schema MCP approval elicitations. Normal Computer Use app-access checks therefore proceed without a per-app prompt, just as they do in Codex Full access. The bridge does not edit the service's persistent per-bundle approval file. If app-server emits an elicitation instead of resolving it under Full access, the bridge still forwards it faithfully to the invoking client; unsupported clients return `cancel`, never a fabricated `accept` or `decline`.
 
-No-permissions does **not** bypass:
+No-permissions leaves the official and transport requirements unchanged:
 
-- macOS Screen Recording, Accessibility, or TCC controls;
-- strict OpenAI Team ID and code-signature checks;
-- exact upstream ten-tool schema verification;
-- canonical app identity resolution and per-user/per-app kernel locks shared across Pi and MCP state roots;
-- focus telemetry, timeouts, verified process-tree cleanup, or private audit logging.
+- macOS Screen Recording, Accessibility, and TCC controls remain authoritative;
+- the adapter still selects and verifies the official signed components required for the supported transport;
+- the wrapper verifies compatibility with the upstream ten-tool contract.
+
+The current release also retains behavior from the earlier background-computer-use wrapper. This includes canonical app resolution, per-user/per-app coordination, focus completion telemetry, process cleanup, and metadata-only audit. These provide compatibility, lifecycle management, and observability. They do not provide extra authorization or a sandbox. Do not use them as a foundation for more wrapper safeguards.
 
 ## Why the signed app-server is required
 
@@ -131,9 +131,9 @@ For Pi's generic MCP gateway, keep `directTools: false` so this powerful surface
 
 The generic MCP server exposes the same no-permissions behavior: official Codex Full access, no wrapper permission gate, and all ten methods. App-access approvals are resolved inside the official host. Any standard form or URL elicitation that app-server emits is forwarded as an MCP `elicitation/create` request. The upstream client response is returned unchanged; unsupported or headless clients cancel rather than fabricate a decision.
 
-## Security and privacy
+## Execution and privacy
 
-Each call:
+For the current released implementation, each call:
 
 1. validates typed arguments;
 2. applies the single durable no-permissions policy with no mode or prompt branch;
@@ -148,7 +148,7 @@ Each call:
 11. rejects any model-turn notification, including during teardown;
 12. combines partial-preserving ancestry enumeration with private-working-directory ownership recovery, then freezes, terminates, and verifies the app-server plus separately grouped or reparented helpers; finally it removes temporary state, releases the lock, and writes a content-safe audit with separate broker/lease cleanup evidence.
 
-Focus checks are detection/completion criteria, not a preventive macOS sandbox. If the target becomes frontmost, the call is reported as failed even though an individual official action may already have completed.
+Focus telemetry is legacy completion behavior from the earlier background-computer-use wrapper. It does not provide an official Codex access control or a preventive macOS sandbox. The current release reports the call as failed if the target becomes frontmost. An individual official action may already have completed. Do not use this telemetry as a reason to add further defensive policy.
 
 Tool results may contain visible target-app text or screenshots because that is the purpose of Computer Use. They return only to the invoking Pi/MCP client. Audits never retain arguments, typed values, screenshots, app-state payloads, result text, prompts, credentials, or tokens—only bounded metadata such as method, canonical/hashed app identity, byte counts, content types, outcome, focus, broker version, and zero-turn evidence.
 
@@ -172,7 +172,7 @@ npm pack --dry-run
 
 Registry dependency tarballs are exact-pinned with integrity and the package includes `npm-shrinkwrap.json`.
 
-See [`PROOF.md`](PROOF.md), [`SECURITY.md`](SECURITY.md), and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+See [`PROOF.md`](PROOF.md), [`SECURITY.md`](SECURITY.md), and [`CONTRIBUTING.md`](CONTRIBUTING.md). Agent contributors must also follow [`AGENTS.md`](AGENTS.md). It records the maintainer's thin-adapter intent and review standard.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Reporting a vulnerability
 
-Do not open a public issue for a vulnerability that could weaken signing, contract verification, no-permissions dispatch, first-party access handling, app identity, locking, focus telemetry, cleanup, or audit integrity.
+Do not open a public issue for a concrete vulnerability in the supported production path. This includes realistic paths to untrusted component execution, unauthorized wrapper dispatch, credential or result-content exposure, or materially false completion reporting.
 
-Use GitHub private vulnerability reporting. Include the affected commit/version, the smallest non-sensitive reproduction, expected versus observed behavior, and whether an official action completed before failure.
+Use GitHub private vulnerability reporting. Include the affected commit and version, a small non-sensitive reproduction, and the expected and observed behavior. Provide evidence that the path is realistically reachable. State whether an official action completed before failure. Speculative hardening ideas without a reachable material effect are not vulnerability reports.
 
 Never include credentials, tokens, customer/private content, sensitive screenshots, raw app-state payloads, elicitation contents, or private audit files.
 
@@ -16,7 +16,15 @@ The API requires a loaded thread ID. The bridge creates an empty, pathless, ephe
 
 This is direct tool dispatch—not model orchestration.
 
-## Security invariants
+## Authority and non-goals
+
+This package is a thin adapter to official Codex Computer Use. Codex and macOS remain authoritative for tool behavior, app access, and platform permissions. The wrapper must not add permission policy, risk classification, app allowlists, action gates, content inspection, or speculative defence-in-depth.
+
+The earlier background-computer-use wrapper provided canonical app resolution, same-app locking, focus completion telemetry, and metadata-only audit. The current release retains these legacy behaviors. They do not provide independent security or authorization boundaries. Do not expand them because a hypothetical safeguard is possible. A maintainer must explicitly approve their removal or material simplification because this changes the release contract.
+
+## Current adapter invariants
+
+These invariants describe the supported transport, zero-model-turn architecture, current released behavior, process lifecycle, and privacy contract. They are not a general security framework or a mandate to add safeguards.
 
 1. Only the fixed app-bundled Codex path and reviewed official Computer Use layouts are allowed in production. The current client is resolved from the OS account home under `~/.codex/computer-use/`; `HOME`, `CODEX_HOME`, arbitrary paths, and symlinked layouts are not accepted. The former exact plugin-bundle layout is considered only when the current component is absent.
 2. Both binaries pass strict code-signature verification and OpenAI Team ID `2DC432GLL2` checks before dispatch. A present current-layout client that fails verification never falls back.
@@ -24,9 +32,9 @@ This is direct tool dispatch—not model orchestration.
 4. `no-permissions` is the only wrapper policy: all ten methods are exposed and no wrapper permission prompt is opened.
 5. There is no config file, environment override, command, tool argument, per-call branch, or alternate safe/full route that an agent can select.
 6. App-server uses the official Full access combination, `approvalPolicy: "never"` plus `sandbox: "danger-full-access"`. The pinned Codex host automatically accepts empty-schema MCP approval elicitations, so normal first-party app-access checks proceed without prompts. The wrapper does not synthesize this response or edit persistent per-app approvals. Any elicitation app-server emits is forwarded faithfully; an unavailable client cancels.
-7. Target selectors resolve to canonical installed bundle IDs before dispatch.
-8. Same-app work is excluded across native Pi, generic MCP, and custom state roots with one fixed per-user kernel `lockf` lease namespace.
-9. Target focus events, periodic samples, watcher health, queued ASN resolution, and final state are checked. This is post-action detection, not a preventive OS sandbox.
+7. As current legacy wrapper behavior, target selectors resolve to canonical installed bundle IDs before dispatch.
+8. As current legacy wrapper coordination, same-app work is excluded across native Pi, generic MCP, and custom state roots with one fixed per-user kernel `lockf` lease namespace.
+9. As current legacy completion telemetry, target focus events, periodic samples, watcher health, queued ASN resolution, and final state are checked. This is post-action reporting, not a preventive OS sandbox or an official Codex access control.
 10. One direct request emits one official `mcpServer/tool/call`; no model turn, subagent, shell, web, plugin, prompt, or reachable model transport is available.
 11. App-server and helper share one private broker-session working directory. One-shot calls close it immediately; Pi retains it only across the required `get_app_state` and following action, then closes it after the action, before replacement inspection, or on session shutdown. Cleanup combines strict ancestry enumeration (preserving partial results) with working-directory ownership recovery, freezes processes to a stable set, kills every owned process, awaits stdio closure, and verifies exit. This still finds a helper reparented by an early app-server exit; enumeration/freeze/exit uncertainty is fatal.
 12. Protocol JSONL is bounded before an unterminated line can exceed 8 MB in memory.


### PR DESCRIPTION
## Summary

- add repository agent guidance for the thin transport-adapter design
- distinguish official transport requirements from retained legacy wrapper behaviour
- align review and security documentation with realistic supported paths

## Verification

- `npm ci`
- `npm run check`
- `npm run check:pi`
- `npm test` (68/68)
- `npm run build`
- `git diff --check`