### PR TITLE
release: v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog records user-visible changes from version 0.3.2 onwards.
 
-## Unreleased
+## 0.3.3 - 2026-07-27
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration and rollback
 
-Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 added Pi progressive disclosure, version 0.3.1 followed ChatGPT's current per-user Computer Use component layout, and version 0.3.2 restores one complete direct Pi surface with shared inspection-action session continuity. Use the relevant section below.
+Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 added Pi progressive disclosure, version 0.3.1 followed ChatGPT's current per-user Computer Use component layout, version 0.3.2 restored one complete direct Pi surface with shared inspection-action session continuity, and version 0.3.3 adds macOS 27 compatibility. Use the relevant section below.
 
 ## What changes
 
@@ -100,6 +100,14 @@ Version 0.3.2 activates all ten direct Pi tools at session start and retains one
 
 The exact schemas, strict signature and OpenAI Team ID checks, canonical client and app resolution, Full access policy, zero-turn attestation, inventory validation, kernel lock, focus telemetry, process-tree cleanup, and content-safe audit remain mandatory.
 
+## Upgrade from version 0.3.2 to 0.3.3
+
+Version 0.3.3 accepts both the legacy `CFBundleIdentifier` key and the macOS 27 `bundleID` key from `lsappinfo`. This prevents frontmost-app detection from rejecting official Computer Use dispatch on macOS 27. No configuration migration is required.
+
+1. Verify that npm resolves `codex-computer-use-mcp@0.3.3` exactly, then install that exact package.
+2. Start a fresh Pi process so it loads the updated extension code.
+3. On an unlocked Mac, run `computer_use_get_app_state` against a benign background app and verify that the result succeeds without moving focus.
+
 ## Rollback
 
 1. Stop the current Pi process.
@@ -114,4 +122,4 @@ Direct state can be removed only after rollback evidence is captured and no proc
 
 ## Generic MCP gateway
 
-If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.2` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.
+If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.3` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Computer Use MCP
 
-Version 0.3.2 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
+Version 0.3.3 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
 
 The primary path has:
 
@@ -77,16 +77,16 @@ The direct bridge starts app-server with a new private `CODEX_HOME` containing n
 
 ### Locked-screen limitation
 
-Version 0.3.2 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
+Version 0.3.3 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
 
-OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.2.
+OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.3.
 
 ## Pi integration
 
 Install the exact release from npm:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.2
+pi install npm:codex-computer-use-mcp@0.3.3
 ```
 
 To evaluate a source checkout instead:
@@ -172,7 +172,7 @@ npm pack --dry-run
 
 Registry dependency tarballs are exact-pinned with integrity and the package includes `npm-shrinkwrap.json`.
 
-See [`PROOF.md`](PROOF.md), [`SECURITY.md`](SECURITY.md), and [`CONTRIBUTING.md`](CONTRIBUTING.md). Agent contributors must also follow [`AGENTS.md`](AGENTS.md). It records the maintainer's thin-adapter intent and review standard.
+See [`CHANGELOG.md`](CHANGELOG.md), [`PROOF.md`](PROOF.md), [`SECURITY.md`](SECURITY.md), and [`CONTRIBUTING.md`](CONTRIBUTING.md). Agent contributors must also follow [`AGENTS.md`](AGENTS.md). It records the maintainer's thin-adapter intent and review standard.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,6 @@ Computer Use returns the official app-state text and screenshots to the invoking
 
 ## Supported versions
 
-Only the latest approved release is supported. Version 0.3.2 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
+Only the latest approved release is supported. Version 0.3.3 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
 
 App-server is experimental and bundle paths or schemas can change. Drift fails closed until reviewed.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -13,10 +13,10 @@ CODEX_COMPUTER_USE_HOME="$(mktemp -d)" \
 
 `-ne` prevents an installed 0.1 adapter from loading at the same time. This source workflow does not install or switch live Pi configuration.
 
-For normal installation, use the exact version 0.3.2 npm package:
+For normal installation, use the exact version 0.3.3 npm package:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.2
+pi install npm:codex-computer-use-mcp@0.3.3
 ```
 
 Use the source workflow only when you need to test an exact reviewed commit. Follow the rollback procedure in `MIGRATION.md` when replacing version 0.1.
@@ -48,7 +48,7 @@ No-permissions is the only policy: all ten tools are registered and available th
 
 ## Generic MCP gateway
 
-Merge `mcp.json.example` only for the exact 0.3.2 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
+Merge `mcp.json.example` only for the exact 0.3.3 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
 
 For a source checkout:
 

--- a/integrations/pi/mcp.json.example
+++ b/integrations/pi/mcp.json.example
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "codex-computer-use-mcp@0.3.2"
+        "codex-computer-use-mcp@0.3.3"
       ],
       "lifecycle": "lazy",
       "requestTimeoutMs": 180000,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-computer-use-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Expose the official macOS Computer Use tools directly to Pi and MCP clients without a nested model.",
   "author": "Thomas Mustier",
   "license": "MIT",
@@ -31,6 +31,7 @@
     "integrations/pi",
     "npm-shrinkwrap.json",
     "README.md",
+    "CHANGELOG.md",
     "PROOF.md",
     "ARCHITECTURE.md",
     "MIGRATION.md",

--- a/src/direct-broker.ts
+++ b/src/direct-broker.ts
@@ -663,7 +663,7 @@ export async function createOfficialDirectToolSession(
 		proc.stdout.on("end", () => { if (stdoutBuffer.length > 0) processProtocolLine(stdoutBuffer); stdoutBuffer = ""; });
 
 		await request("initialize", {
-			clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.2" },
+			clientInfo: { name: "pi_direct_computer_use", title: "Pi Direct Computer Use", version: "0.3.3" },
 			capabilities: { mcpServerOpenaiFormElicitation: options.supportsOpenAiFormElicitation === true },
 		}, 15_000);
 		send({ method: "initialized" });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,7 @@ import {
 	OFFICIAL_TOOL_METADATA,
 } from "./tools.ts";
 
-const version = "0.3.2";
+const version = "0.3.3";
 
 async function handleCli(): Promise<boolean> {
 	const args = process.argv.slice(2);

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -11,6 +11,7 @@ test("package contains direct architecture, Pi adapter, docs, and shrinkwrap wit
 	const files = report.files.map((item: { path: string }) => item.path).sort();
 	for (const required of [
 		"ARCHITECTURE.md",
+		"CHANGELOG.md",
 		"MIGRATION.md",
 		"README.md",
 		"SECURITY.md",


### PR DESCRIPTION
## Release

Patch release because the user-visible code change is a backward-compatible macOS compatibility fix.

## Changes since v0.3.2

- accept the macOS 27 `lsappinfo` `bundleID` output while retaining the legacy `CFBundleIdentifier` form
- credit Brad Hallett for the fix in the packaged changelog
- clarify the thin transport-adapter intent and realistic review standard
- update package, runtime, installation, security, and migration version references to 0.3.3

## Verification

- `npm ci`
- `npm run check`
- `npm run check:pi`
- `npm test` (69/69)
- `npm run build`
- `npm pack --dry-run` (41 files; changelog included)
- live signed `list_apps` acceptance passed with zero model turns and verified cleanup
- live signed `get_app_state(Finder)` passed on the exact merged implementation before the version-only release edits

`npm audit --omit=dev` reports only GHSA-frvp-7c67-39w9 through MCP SDK 1.29.0. The advisory concerns Windows path handling in Hono's `serve-static`; this package is Darwin-only and does not serve files through Hono.
