### PR TITLE
Fix native Computer Use focus compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog records user-visible changes from version 0.3.2 onwards.
 
+## 0.3.4 - 2026-07-27
+
+### Fixed
+
+- Match native Computer Use focus behavior: already-frontmost targets, focus changes, and unavailable legacy focus telemetry no longer block or override official tool results. Focus observations remain available in metadata-only audit and response details.
+
 ## 0.3.3 - 2026-07-27
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration and rollback
 
-Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 added Pi progressive disclosure, version 0.3.1 followed ChatGPT's current per-user Computer Use component layout, version 0.3.2 restored one complete direct Pi surface with shared inspection-action session continuity, and version 0.3.3 adds macOS 27 compatibility. Use the relevant section below.
+Version 0.2.0 was the breaking direct-tool architecture change from version 0.1.0. Version 0.3.0 added Pi progressive disclosure, version 0.3.1 followed ChatGPT's current per-user Computer Use component layout, version 0.3.2 restored one complete direct Pi surface with shared inspection-action session continuity, version 0.3.3 added macOS 27 compatibility, and version 0.3.4 aligns focus behavior with native Computer Use. Use the relevant section below.
 
 ## What changes
 
@@ -102,11 +102,20 @@ The exact schemas, strict signature and OpenAI Team ID checks, canonical client 
 
 ## Upgrade from version 0.3.2 to 0.3.3
 
-Version 0.3.3 accepts both the legacy `CFBundleIdentifier` key and the macOS 27 `bundleID` key from `lsappinfo`. This prevents frontmost-app detection from rejecting official Computer Use dispatch on macOS 27. No configuration migration is required.
+Version 0.3.3 accepts both the legacy `CFBundleIdentifier` key and the macOS 27 `bundleID` key from `lsappinfo`.
 
 1. Verify that npm resolves `codex-computer-use-mcp@0.3.3` exactly, then install that exact package.
 2. Start a fresh Pi process so it loads the updated extension code.
 3. On an unlocked Mac, run `computer_use_get_app_state` against a benign background app and verify that the result succeeds without moving focus.
+
+## Upgrade from version 0.3.3 to 0.3.4
+
+Version 0.3.4 removes the legacy background-only focus gate. Calls now match native Computer Use when a target is already frontmost, changes focus, or focus telemetry is unavailable. Focus observations remain metadata-only telemetry. No configuration migration is required.
+
+1. Verify that npm resolves `codex-computer-use-mcp@0.3.4` exactly, then install that exact package.
+2. Start a fresh Pi process so it loads the updated extension code.
+3. On an unlocked Mac, make a benign app frontmost, then run `computer_use_get_app_state` followed by `computer_use_press_key` with `ESC` against that same app.
+4. Verify both calls succeed, `backgroundPreserved` records `false`, the pair uses one zero-turn ephemeral session, and cleanup completes.
 
 ## Rollback
 
@@ -122,4 +131,4 @@ Direct state can be removed only after rollback evidence is captured and no proc
 
 ## Generic MCP gateway
 
-If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.3` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.
+If Pi uses `mcp.json`, retain `directTools: false`. Use the exact `0.3.4` package shown in `integrations/pi/mcp.json.example`. During source acceptance, use a distinct temporary server name and source path, then remove it. The direct Pi adapter is the primary live path; do not leave the version 0.1 aggregate server active after the switch.

--- a/PROOF.md
+++ b/PROOF.md
@@ -66,7 +66,7 @@ Current branch tests cover:
 - unrestricted read and mutation dispatch under the single no-permissions policy;
 - absence of wrapper app/intent/action gates and permission prompts;
 - canonical bundle-ID dispatch;
-- target focus violation fail-closed behavior;
+- native-compatible focus behavior for already-frontmost targets, focus changes, and unavailable legacy telemetry;
 - official error preservation;
 - private metadata-only audits with no arguments/results and truthful separate broker/lease cleanup evidence;
 - secure audit-directory/file no-follow and mode checks;
@@ -79,6 +79,12 @@ Current branch tests cover:
 - Pi session-start registration and activation of all ten direct definitions while preserving unrelated active tools;
 - one retained broker/client session across `get_app_state` and the following action, with deterministic active-app lease continuity and verified close;
 - Pi form, opaque OpenAI-form, URL, decline, and headless-cancel elicitation handling.
+
+## Version 0.3.4 native focus compatibility
+
+Before the change, a live installed-path call targeting frontmost TextEdit was rejected with `Target app is already frontmost; direct background-only dispatch was refused`; the official broker was never called. The same signed official path accepted a state read when hosted by native ChatGPT, confirming the rejection was wrapper-only.
+
+After the change, a retained signed-client session targeted the app that was already frontmost and completed `get_app_state` followed by harmless `ESC`. Both audits recorded `outcome=ok`, `directCalls=1`, `modelTurnsStarted=0`, `ephemeralThread=true`, `backgroundPreserved=false`, and `appLeaseReleased=true`; cleanup was verified when the retained session closed after the action. No app-state text or screenshot was retained.
 
 ## Official Full access approval probe
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Computer Use MCP
 
-Version 0.3.3 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
+Version 0.3.4 exposes the official signed macOS Computer Use capabilities as direct typed tools for Pi and MCP clients. The calling agent chooses every tool and argument itself.
 
 The primary path has:
 
@@ -77,16 +77,16 @@ The direct bridge starts app-server with a new private `CODEX_HOME` containing n
 
 ### Locked-screen limitation
 
-Version 0.3.3 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
+Version 0.3.4 supports direct local calls in an unlocked macOS session. It does not support window or accessibility actions after the Mac locks.
 
-OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.3.
+OpenAI's [locked Computer Use](https://developers.openai.com/codex/app/computer-use#use-computer-use-while-your-mac-is-locked) is limited to active, trusted ChatGPT turns started from a connected device. It does not authorize other apps or local processes to unlock the Mac. This package uses local zero-turn dispatch, so targeted calls can fail with official error `-10005` while the Mac is locked. Support for locked local use remains a follow-up and is not part of version 0.3.4.
 
 ## Pi integration
 
 Install the exact release from npm:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.3
+pi install npm:codex-computer-use-mcp@0.3.4
 ```
 
 To evaluate a source checkout instead:
@@ -148,7 +148,7 @@ For the current released implementation, each call:
 11. rejects any model-turn notification, including during teardown;
 12. combines partial-preserving ancestry enumeration with private-working-directory ownership recovery, then freezes, terminates, and verifies the app-server plus separately grouped or reparented helpers; finally it removes temporary state, releases the lock, and writes a content-safe audit with separate broker/lease cleanup evidence.
 
-Focus telemetry is legacy completion behavior from the earlier background-computer-use wrapper. It does not provide an official Codex access control or a preventive macOS sandbox. The current release reports the call as failed if the target becomes frontmost. An individual official action may already have completed. Do not use this telemetry as a reason to add further defensive policy.
+Focus telemetry is legacy observational behavior from the earlier background-computer-use wrapper. It does not provide an official Codex access control or a preventive macOS sandbox. Matching native Computer Use, the wrapper permits calls when the target is already frontmost and does not convert a completed official call into an error when focus changes or telemetry is unavailable. `backgroundPreserved` records the observation without gating the result. Do not use this telemetry as a reason to add further defensive policy.
 
 Tool results may contain visible target-app text or screenshots because that is the purpose of Computer Use. They return only to the invoking Pi/MCP client. Audits never retain arguments, typed values, screenshots, app-state payloads, result text, prompts, credentials, or tokens—only bounded metadata such as method, canonical/hashed app identity, byte counts, content types, outcome, focus, broker version, and zero-turn evidence.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ These invariants describe the supported transport, zero-model-turn architecture,
 6. App-server uses the official Full access combination, `approvalPolicy: "never"` plus `sandbox: "danger-full-access"`. The pinned Codex host automatically accepts empty-schema MCP approval elicitations, so normal first-party app-access checks proceed without prompts. The wrapper does not synthesize this response or edit persistent per-app approvals. Any elicitation app-server emits is forwarded faithfully; an unavailable client cancels.
 7. As current legacy wrapper behavior, target selectors resolve to canonical installed bundle IDs before dispatch.
 8. As current legacy wrapper coordination, same-app work is excluded across native Pi, generic MCP, and custom state roots with one fixed per-user kernel `lockf` lease namespace.
-9. As current legacy completion telemetry, target focus events, periodic samples, watcher health, queued ASN resolution, and final state are checked. This is post-action reporting, not a preventive OS sandbox or an official Codex access control.
+9. As legacy observational telemetry, target focus events, periodic samples, watcher health, queued ASN resolution, and final state are recorded without gating official dispatch or results. This is reporting, not a preventive OS sandbox or an official Codex access control.
 10. One direct request emits one official `mcpServer/tool/call`; no model turn, subagent, shell, web, plugin, prompt, or reachable model transport is available.
 11. App-server and helper share one private broker-session working directory. One-shot calls close it immediately; Pi retains it only across the required `get_app_state` and following action, then closes it after the action, before replacement inspection, or on session shutdown. Cleanup combines strict ancestry enumeration (preserving partial results) with working-directory ownership recovery, freezes processes to a stable set, kills every owned process, awaits stdio closure, and verifies exit. This still finds a helper reparented by an early app-server exit; enumeration/freeze/exit uncertainty is fatal.
 12. Protocol JSONL is bounded before an unterminated line can exceed 8 MB in memory.
@@ -64,6 +64,6 @@ Computer Use returns the official app-state text and screenshots to the invoking
 
 ## Supported versions
 
-Only the latest approved release is supported. Version 0.3.3 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
+Only the latest approved release is supported. Version 0.3.4 supports direct local calls in an unlocked macOS session. Targeted local calls while the Mac is locked are not supported.
 
 App-server is experimental and bundle paths or schemas can change. Drift fails closed until reviewed.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -13,10 +13,10 @@ CODEX_COMPUTER_USE_HOME="$(mktemp -d)" \
 
 `-ne` prevents an installed 0.1 adapter from loading at the same time. This source workflow does not install or switch live Pi configuration.
 
-For normal installation, use the exact version 0.3.3 npm package:
+For normal installation, use the exact version 0.3.4 npm package:
 
 ```bash
-pi install npm:codex-computer-use-mcp@0.3.3
+pi install npm:codex-computer-use-mcp@0.3.4
 ```
 
 Use the source workflow only when you need to test an exact reviewed commit. Follow the rollback procedure in `MIGRATION.md` when replacing version 0.1.
@@ -48,7 +48,7 @@ No-permissions is the only policy: all ten tools are registered and available th
 
 ## Generic MCP gateway
 
-Merge `mcp.json.example` only for the exact 0.3.3 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
+Merge `mcp.json.example` only for the exact 0.3.4 package or after building an exact reviewed source commit. `directTools: false` is intentional; it keeps this powerful generic MCP surface behind Pi's gateway.
 
 For a source checkout:
 

--- a/integrations/pi/mcp.json.example
+++ b/integrations/pi/mcp.json.example
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "codex-computer-use-mcp@0.3.3"
+        "codex-computer-use-mcp@0.3.4"
       ],
       "lifecycle": "lazy",
       "requestTimeoutMs": 180000,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-computer-use-mcp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Expose the official macOS Computer Use tools directly to Pi and MCP clients without a nested model.",
   "author": "Thomas Mustier",
   "license": "MIT",

--- a/src/direct-service.ts
+++ b/src/direct-service.ts
@@ -185,6 +185,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 	let frontBefore: string | undefined;
 	let targetBecameFrontmost = false;
 	let unrelatedFocusChanges = false;
+	let backgroundPreserved: boolean | null = null;
 	let broker: DirectBrokerResult | undefined;
 	let brokerFailure: DirectBrokerCallError | undefined;
 	let brokerDispatchAttempted = false;
@@ -197,18 +198,16 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 		if (identity) lock = await (deps.acquireLock ?? acquireAppLock)(globalAppLockRoot(), identity.leaseId, runId);
 		if (identity?.bundleId) {
 			frontBefore = (deps.frontmost ?? frontmostBundleId)();
-			if (!frontBefore) throw new DirectPolicyError("Could not observe the frontmost app before direct dispatch");
-			if (frontBefore.toLowerCase() === identity.bundleId.toLowerCase()) {
-				throw new DirectPolicyError("Target app is already frontmost; direct background-only dispatch was refused");
-			}
-			watcher = await (deps.watchFocus ?? watchTargetFrontmost)();
+			if (frontBefore?.toLowerCase() === identity.bundleId.toLowerCase()) targetBecameFrontmost = true;
+			try { watcher = await (deps.watchFocus ?? watchTargetFrontmost)(); }
+			catch { focusSamplingFailed = true; }
 			const sample = async (): Promise<void> => {
 				if (focusSample) return focusSample;
 				focusSample = (async () => {
 					const current = await (deps.frontmostAsync ?? frontmostBundleIdAsync)();
 					if (!current) return;
 					if (current.toLowerCase() === identity.bundleId!.toLowerCase()) targetBecameFrontmost = true;
-					else if (current !== frontBefore) unrelatedFocusChanges = true;
+					else if (frontBefore && current !== frontBefore) unrelatedFocusChanges = true;
 				})().finally(() => { focusSample = undefined; });
 				return focusSample;
 			};
@@ -279,12 +278,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 			else if (frontAfter.toLowerCase() === identity.bundleId.toLowerCase()) targetBecameFrontmost = true;
 			else if (frontBefore && frontAfter !== frontBefore) unrelatedFocusChanges = true;
 		}
-		const backgroundPreserved = identity ? !targetBecameFrontmost && !watcherFailed : null;
-		if (identity && backgroundPreserved !== true && !thrown) {
-			outcome = "focus_violation";
-			thrown = new DirectPolicyError("Target focus changed or focus telemetry failed; the completed tool call is not trusted as background-safe");
-			response = undefined;
-		}
+		backgroundPreserved = identity ? !targetBecameFrontmost && !watcherFailed : null;
 		let releaseFailed = false;
 		try { await lock?.release(); } catch { releaseFailed = true; }
 		if (releaseFailed) {
@@ -321,7 +315,7 @@ export async function executeDirectTool(raw: unknown, deps: DirectServiceDepende
 	}
 	if (thrown) throw thrown;
 	if (!response) throw new Error("Direct Computer Use ended without a result");
-	response.details.backgroundPreserved = identity ? true : null;
+	response.details.backgroundPreserved = backgroundPreserved;
 	response.details.unrelatedFocusChanges = unrelatedFocusChanges;
 	response.details.brokerCleanupVerified = brokerCleanupVerified;
 	return response;

--- a/src/system.ts
+++ b/src/system.ts
@@ -11,9 +11,7 @@ const execFileAsync = promisify(execFile);
  * Upstream API assumption: LaunchServices changed the emitted key across macOS
  * releases. macOS <= 26 prints `"CFBundleIdentifier"="com.example"`; macOS 27+
  * (Darwin 27) prints `bundleID="com.example"` and drops `CFBundleIdentifier`.
- * Accept both spellings so frontmost detection survives the rename; otherwise
- * `frontmostBundleId()` returns `undefined` and every direct dispatch throws
- * "Could not observe the frontmost app" before reaching the broker.
+ * Accept both spellings so retained focus telemetry survives the rename.
  */
 export function parseLsappinfoBundleId(stdout: string): string | undefined {
 	return stdout.match(/(?:"CFBundleIdentifier"|bundleID)="([^"]+)"/)?.[1];

--- a/test/direct-service.test.ts
+++ b/test/direct-service.test.ts
@@ -138,18 +138,38 @@ test("no-permissions has no wrapper app, intent, or action gate", async () => {
 	} finally { await rm(root, { recursive: true, force: true }); }
 });
 
-test("focus telemetry fails closed after a completed direct action", async () => {
+test("an already-frontmost target dispatches like native Computer Use", async () => {
+	const root = await mkdtemp(path.join(os.tmpdir(), "direct-service-frontmost-test."));
+	let dispatched = false;
+	try {
+		const testDeps = deps(root, async () => { dispatched = true; return brokerResult("pressed"); });
+		testDeps.frontmost = () => "com.apple.TextEdit";
+		testDeps.frontmostAsync = async () => "com.apple.TextEdit";
+		const response = await executeDirectTool(
+			{ method: "press_key", arguments: { app: "TextEdit", key: "ESC" } },
+			testDeps,
+		);
+		assert.equal(response.ok, true);
+		assert.equal(dispatched, true);
+		assert.equal(response.details.backgroundPreserved, false);
+		const audit = JSON.parse((await readFile(path.join(root, "audit", "direct-computer-use.jsonl"), "utf8")).trim());
+		assert.equal(audit.outcome, "ok");
+		assert.equal(audit.backgroundPreserved, false);
+		assert.equal(audit.directCalls, 1);
+	} finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("focus changes remain non-blocking telemetry after a completed direct action", async () => {
 	const root = await mkdtemp(path.join(os.tmpdir(), "direct-service-focus-test."));
 	try {
-		await assert.rejects(
-			executeDirectTool(
-				{ method: "press_key", arguments: { app: "TextEdit", key: "ESC" } },
-				deps(root, async () => brokerResult("pressed"), true),
-			),
-			/background-safe/,
+		const response = await executeDirectTool(
+			{ method: "press_key", arguments: { app: "TextEdit", key: "ESC" } },
+			deps(root, async () => brokerResult("pressed"), true),
 		);
+		assert.equal(response.ok, true);
+		assert.equal(response.details.backgroundPreserved, false);
 		const audit = JSON.parse((await readFile(path.join(root, "audit", "direct-computer-use.jsonl"), "utf8")).trim());
-		assert.equal(audit.outcome, "focus_violation");
+		assert.equal(audit.outcome, "ok");
 		assert.equal(audit.backgroundPreserved, false);
 		assert.equal(audit.directCalls, 1);
 	} finally { await rm(root, { recursive: true, force: true }); }
@@ -184,24 +204,26 @@ test("broker failures preserve content-safe architecture evidence in audit", asy
 	} finally { await rm(root, { recursive: true, force: true }); }
 });
 
-test("asynchronous focus sampling failures are handled and fail closed", async () => {
+test("focus telemetry failures do not block native-compatible dispatch", async () => {
 	const root = await mkdtemp(path.join(os.tmpdir(), "direct-service-sample-test."));
 	try {
 		const testDeps = deps(root, async () => {
 			await new Promise((resolve) => setTimeout(resolve, 150));
 			return brokerResult("pressed");
 		});
+		testDeps.frontmost = () => undefined;
 		testDeps.frontmostAsync = async () => { throw new Error("sample failed"); };
-		await assert.rejects(
-			executeDirectTool(
-				{ method: "press_key", arguments: { app: "TextEdit", key: "ESC" } },
-				testDeps,
-			),
-			/background-safe/,
+		testDeps.watchFocus = async () => { throw new Error("watcher failed"); };
+		const response = await executeDirectTool(
+			{ method: "press_key", arguments: { app: "TextEdit", key: "ESC" } },
+			testDeps,
 		);
+		assert.equal(response.ok, true);
+		assert.equal(response.details.backgroundPreserved, false);
 		const audit = JSON.parse((await readFile(path.join(root, "audit", "direct-computer-use.jsonl"), "utf8")).trim());
-		assert.equal(audit.outcome, "focus_violation");
+		assert.equal(audit.outcome, "ok");
 		assert.equal(audit.backgroundPreserved, false);
+		assert.equal(audit.directCalls, 1);
 	} finally { await rm(root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
Closes #14.

## Summary

- permit official calls when the target app is already frontmost
- retain focus changes and telemetry health as non-blocking `backgroundPreserved` observations
- preserve signature/Team ID verification, responsible-process transport, zero-turn attestation, session continuity, locking, cleanup, and metadata-only audit behavior
- add deterministic regressions and 0.3.4 release/migration guidance

## Verification

- `npm ci`
- `npm run check`
- `npm run check:pi`
- `npm test` (70/70)
- `npm run build`
- `npm pack --dry-run`
- live signed retained-session `get_app_state` → harmless `ESC` against an already-frontmost app; both official calls succeeded, zero model turns were recorded, leases released, and cleanup verified on session close
- independent exact-head review of `1f3b77d927a70d73c6aa1d86a35c0f71ee0440e8`: approved