### PR TITLE
Replace Pi computer use primitives with one code tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@ This package is a thin transport adapter to OpenAI's official signed macOS Compu
 
 ## Scope
 
-- Preserve the official ten-tool surface and no-permissions behaviour.
+- Preserve all ten official methods and no-permissions behaviour. MCP exposes them as typed tools; Pi may expose the same methods through one composable `computer_use({ code })` tool.
 - Do not add wrapper permission prompts, app or intent allowlists, action gates, risk classifiers, content inspection, alternate modes or model-driven planning.
 - Do not reintroduce app rewriting, same-app locking or focus telemetry.
 - Add adapter logic only for transport compatibility, zero-model-turn execution, retained official sessions, process lifecycle, packaging or a concrete user-visible bug.
 - Keep signature and Team ID verification, isolated temporary state, model-turn rejection and process cleanup.
+- Run model-authored Pi code outside Pi's main thread with real cancellation, and preserve emitted observations plus completed-call history when a batch stops partway through.
 - Preserve compatible additional tool arguments and pass app selectors through unchanged.
 
 ## Review

--- a/README.md
+++ b/README.md
@@ -22,22 +22,25 @@ Install from npm:
 pi install npm:codex-computer-use-mcp
 ```
 
-The extension registers and activates these tools:
+The extension registers and activates one composable tool:
 
 ```text
-computer_use_list_apps
-computer_use_get_app_state
-computer_use_click
-computer_use_perform_secondary_action
-computer_use_set_value
-computer_use_select_text
-computer_use_scroll
-computer_use_drag
-computer_use_press_key
-computer_use_type_text
+computer_use({ code: string })
 ```
 
-Use `/computer-use-status` to inspect the installed component and transport status.
+The code runs with `sky`, `emit`, `emitImage` and a persistent `store` object. `sky` exposes all ten official Computer Use methods, so known sequential actions can run without a model round-trip between each action:
+
+```js
+const state = await sky.get_app_state({ app: "TextEdit" });
+emit(state.text);
+
+await sky.click({ app: "TextEdit", element_index: "7" });
+await sky.type_text({ app: "TextEdit", text: "hello" });
+const next = await sky.get_app_state({ app: "TextEdit" });
+emit(next.text);
+```
+
+Only values passed to `emit(...)` or `emitImage(...)` are returned to Pi. Use `/computer-use-status` to inspect the installed component and transport status.
 
 To run a source checkout:
 
@@ -73,7 +76,7 @@ Example Pi MCP configuration:
 
 ## Behaviour
 
-The adapter has one mode. All ten official methods are available without wrapper permission prompts. It adds no app allowlist, action gate, intent classifier, selector rewrite or focus policy. App-server uses Codex Full access. The adapter forwards any elicitation that the official host still emits.
+The adapter has one mode. Pi exposes the ten official methods through the single `computer_use` code tool; MCP exposes them as ten typed methods. Both are available without wrapper permission prompts. It adds no app allowlist, action gate, intent classifier, selector rewrite or focus policy. App-server uses Codex Full access. The adapter forwards any elicitation that the official host still emits.
 
 Production calls require verified OpenAI-signed app-server and Computer Use binaries with Team ID `2DC432GLL2`. The adapter uses an isolated, credential-free app-server context. It rejects any model-turn activity. Calls after `get_app_state` reuse the signed session, preserving element identifiers and official app state.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const next = await sky.get_app_state({ app: "TextEdit" });
 emit(next.text);
 ```
 
-Only values passed to `emit(...)` or `emitImage(...)` are returned to Pi. `list_apps` returns the official text inventory produced by the app-server transport. Code runs in a worker so an unbounded loop can be terminated without freezing Pi; time spent inside an official Computer Use call does not count toward the code execution slice. If a later action fails, Pi still receives earlier emitted observations and the attempted method sequence.
+Only values passed to `emit(...)` or `emitImage(...)` are returned to Pi. `list_apps` returns the official text inventory produced by the app-server transport; unlike native `@oai/sky`, that transport does not provide the structured app array. `get_app_state` may return an accessibility-tree diff after the first inspection; pass `disableDiff: true` to request a fresh full tree. Screenshot payloads remain in the parent process and cross the code-worker boundary only as small opaque handles. Code runs in a worker so an unbounded loop can be terminated without freezing Pi; time spent inside an official Computer Use call does not count toward the code execution slice. If a later action fails, Pi still receives earlier emitted observations and the attempted method sequence.
 
 Use `/computer-use-status` to inspect the installed component and transport status.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ const next = await sky.get_app_state({ app: "TextEdit" });
 emit(next.text);
 ```
 
-Only values passed to `emit(...)` or `emitImage(...)` are returned to Pi. Use `/computer-use-status` to inspect the installed component and transport status.
+Only values passed to `emit(...)` or `emitImage(...)` are returned to Pi. `list_apps` returns the official text inventory produced by the app-server transport. Code runs in a worker so an unbounded loop can be terminated without freezing Pi; time spent inside an official Computer Use call does not count toward the code execution slice. If a later action fails, Pi still receives earlier emitted observations and the attempted method sequence.
+
+Use `/computer-use-status` to inspect the installed component and transport status.
 
 To run a source checkout:
 

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -49,6 +49,8 @@ Available globals:
 - emitImage(state.screenshot) returns a screenshot to Pi
 - store is a persistent JSON object shared across calls
 
+get_app_state may return an accessibility-tree diff after the first inspection. Pass disableDiff: true when you need a fresh full tree. Screenshot payloads stay outside the worker and cross it only as opaque handles.
+
 Example:
 const state = await sky.get_app_state({ app: "TextEdit" });
 emit(state.text);
@@ -64,29 +66,42 @@ export async function toPiContent(content: JsonObject[]): Promise<PiContentResul
   const textBlocks = content
     .filter((block) => block.type !== "image")
     .map((block) => String(block.text ?? ""));
-  const truncations = textBlocks.map((text) => truncateHead(text, {
+  const fullText = textBlocks.join("\n\n");
+  const aggregate = truncateHead(fullText, {
     maxLines: DEFAULT_MAX_LINES,
     maxBytes: DEFAULT_MAX_BYTES,
-  }));
+  });
   let fullOutputPath: string | undefined;
-  if (truncations.some((result) => result.truncated)) {
+  if (aggregate.truncated) {
     const tempDir = await mkdtemp(path.join(tmpdir(), "pi-computer-use-"));
     fullOutputPath = path.join(tempDir, "output.txt");
-    await writeFile(fullOutputPath, textBlocks.join("\n\n"), { encoding: "utf8", mode: 0o600 });
+    await writeFile(fullOutputPath, fullText, { encoding: "utf8", mode: 0o600 });
   }
 
   const result: PiContentResult = { content: [] };
+  let remainingText = aggregate.content;
   let textIndex = 0;
+  let truncationNoticeAdded = false;
+  const suffix = `\n\n[Official Computer Use text truncated: showing ${aggregate.outputLines} of ${aggregate.totalLines} lines (${formatSize(aggregate.outputBytes)} of ${formatSize(aggregate.totalBytes)}). Full output saved to: ${fullOutputPath}]`;
   for (const block of content) {
     if (block.type === "image") {
       result.content.push({ type: "image", data: String(block.data), mimeType: String(block.mimeType) });
       continue;
     }
-    const truncated = truncations[textIndex++];
-    const suffix = truncated.truncated
-      ? `\n\n[Official Computer Use text truncated: showing ${truncated.outputLines} of ${truncated.totalLines} lines (${formatSize(truncated.outputBytes)} of ${formatSize(truncated.totalBytes)}). Full output saved to: ${fullOutputPath}]`
-      : "";
-    result.content.push({ type: "text", text: `${truncated.content}${suffix}` });
+    const blockText = String(block.text ?? "");
+    if (!aggregate.truncated) {
+      result.content.push({ type: "text", text: blockText });
+      continue;
+    }
+    if (textIndex > 0 && remainingText.startsWith("\n\n")) remainingText = remainingText.slice(2);
+    textIndex += 1;
+    const retained = blockText.slice(0, remainingText.length);
+    remainingText = remainingText.slice(retained.length);
+    const truncatedHere = retained.length < blockText.length || (remainingText.length === 0 && textIndex < textBlocks.length);
+    if (!retained && !truncatedHere) continue;
+    const notice = truncatedHere && !truncationNoticeAdded ? suffix : "";
+    truncationNoticeAdded ||= truncatedHere;
+    result.content.push({ type: "text", text: `${retained}${notice}` });
   }
   if (fullOutputPath) result.fullOutputPath = fullOutputPath;
   return result;

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -16,21 +16,44 @@ import {
   type DirectBrokerElicitationRequest,
   type DirectBrokerElicitationResponse,
 } from "../../dist/direct-broker.js";
-import { DirectSessionExecutor } from "../../dist/session-executor.js";
-import {
-  TOOL_INPUT_SCHEMAS,
-  TOOL_METADATA,
-  COMPUTER_USE_METHODS,
-  type DirectMethod,
-  type JsonObject,
-} from "../../dist/tools.js";
+import { ComputerUseCodeExecutor } from "../../dist/code-executor.js";
+import { type JsonObject } from "../../dist/tools.js";
 
 const jsonObjectSchema = z.record(z.string(), z.json());
-const toolNames = COMPUTER_USE_METHODS.map((method) => `computer_use_${method}`);
+const codeParameters = {
+  type: "object",
+  additionalProperties: false,
+  required: ["code"],
+  properties: {
+    code: {
+      type: "string",
+      description: "JavaScript body to execute. Use await sky.<method>(args), emit(value), emitImage(screenshot), and store for state shared across calls.",
+    },
+  },
+} as const;
 
-function titleFor(method: DirectMethod): string {
-  return method.split("_").map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`).join(" ");
-}
+const codeDescription = `Run JavaScript that composes OpenAI's official signed macOS Computer Use methods in one call. No nested model is used.
+
+Available globals:
+- sky.list_apps() -> app inventory
+- sky.get_app_state({ app, disableDiff? }) -> { app, text, screenshot }
+- sky.click({ app, element_index?, x?, y?, mouse_button?, click_count? })
+- sky.perform_secondary_action({ app, element_index, action })
+- sky.set_value({ app, element_index, value })
+- sky.select_text({ app, element_index, text, prefix?, suffix?, selection? })
+- sky.scroll({ app, element_index, direction, pages? })
+- sky.drag({ app, from_x, from_y, to_x, to_y })
+- sky.press_key({ app, key })
+- sky.type_text({ app, text })
+- emit(value) returns text or JSON to Pi
+- emitImage(state.screenshot) returns a screenshot to Pi
+- store is a persistent JSON object shared across calls
+
+Example:
+const state = await sky.get_app_state({ app: "TextEdit" });
+emit(state.text);
+
+Batch known actions sequentially, then inspect again before deciding the next step.`;
 
 interface PiContentResult {
   content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>;
@@ -127,7 +150,7 @@ export async function handleOfficialElicitation(
 
 export default function directComputerUse(pi: ExtensionAPI) {
   const stateRoot = process.env.CODEX_COMPUTER_USE_HOME || path.join(getAgentDir(), "direct-computer-use");
-  const sessionExecutor = new DirectSessionExecutor();
+  const codeExecutor = new ComputerUseCodeExecutor();
 
   pi.registerCommand("computer-use-status", {
     description: "Show Computer Use status",
@@ -136,50 +159,39 @@ export default function directComputerUse(pi: ExtensionAPI) {
     },
   });
 
-  for (const method of COMPUTER_USE_METHODS) {
-    const piName = `computer_use_${method}`;
-    pi.registerTool({
-      name: piName,
-      label: titleFor(method),
-      description: TOOL_METADATA[method].description,
-      // SAFETY: Pi accepts standard JSON Schema objects; these schemas are generated directly from the tool's Zod parser.
-      parameters: TOOL_INPUT_SCHEMAS[method] as any,
-      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-        const parsedParams = jsonObjectSchema.parse(params);
-        const response = await sessionExecutor.execute(method, parsedParams, {
-          stateRoot,
-          signal,
-          supportsOpenAiFormElicitation: true,
-          onElicitation: (request) => handleOfficialElicitation(
-            request,
-            ctx,
-            async (url) => (await pi.exec("/usr/bin/open", ["--", url], { signal, timeout: 15_000 })).code === 0,
-          ),
-        });
-        if (response.isError) {
-          const message = response.content
-            .filter((block) => block.type === "text")
-            .map((block) => String(block.text ?? ""))
-            .join("\n")
-            .slice(0, 2_000);
-          throw new Error(message || "Official Computer Use returned an error");
-        }
-        const rendered = await toPiContent(response.content);
-        const details: JsonObject = {};
-        if (response.structuredContent !== undefined) details.officialStructuredContent = response.structuredContent;
-        if (rendered.fullOutputPath) details.fullOutputPath = rendered.fullOutputPath;
-        return { content: rendered.content, details };
-      },
-      renderCall(args, theme) {
-        const parsed = z.object({ app: z.string().optional() }).safeParse(args);
-        const app = parsed.success ? parsed.data.app : undefined;
-        const label = theme.fg("toolTitle", theme.bold(piName));
-        return new Text(app ? `${label} ${theme.fg("accent", app)}` : label, 0, 0);
-      },
-    });
-  }
+  pi.registerTool({
+    name: "computer_use",
+    label: "Computer Use",
+    description: codeDescription,
+    promptSnippet: "Run composable JavaScript against OpenAI's official signed macOS Computer Use surface",
+    promptGuidelines: [
+      "Use computer_use for macOS app UI work, composing known sequential actions in one JavaScript call and emitting only the state needed for the next decision.",
+    ],
+    // SAFETY: Pi accepts this standard JSON Schema object as a custom-tool parameter schema.
+    parameters: codeParameters as any,
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const { code } = z.object({ code: z.string() }).parse(params);
+      const result = await codeExecutor.execute(code, {
+        stateRoot,
+        signal,
+        supportsOpenAiFormElicitation: true,
+        onElicitation: (request) => handleOfficialElicitation(
+          request,
+          ctx,
+          async (url) => (await pi.exec("/usr/bin/open", ["--", url], { signal, timeout: 15_000 })).code === 0,
+        ),
+      });
+      const rendered = await toPiContent(result.content);
+      const details: JsonObject = { calls: result.calls };
+      if (rendered.fullOutputPath) details.fullOutputPath = rendered.fullOutputPath;
+      return { content: rendered.content, details };
+    },
+    renderCall(_args, theme) {
+      return new Text(theme.fg("toolTitle", theme.bold("computer_use")), 0, 0);
+    },
+  });
 
-  pi.on("session_start", () => pi.setActiveTools([...new Set([...pi.getActiveTools(), ...toolNames])]));
-  pi.on("agent_settled", () => sessionExecutor.close());
-  pi.on("session_shutdown", () => sessionExecutor.close());
+  pi.on("session_start", () => pi.setActiveTools([...new Set([...pi.getActiveTools(), "computer_use"])]));
+  pi.on("agent_settled", () => codeExecutor.close());
+  pi.on("session_shutdown", () => codeExecutor.close());
 }

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -35,7 +35,7 @@ const codeParameters = {
 const codeDescription = `Run JavaScript that composes OpenAI's official signed macOS Computer Use methods in one call. No nested model is used.
 
 Available globals:
-- sky.list_apps() -> app inventory
+- sky.list_apps() -> text app inventory
 - sky.get_app_state({ app, disableDiff? }) -> { app, text, screenshot }
 - sky.click({ app, element_index?, x?, y?, mouse_button?, click_count? })
 - sky.perform_secondary_action({ app, element_index, action })
@@ -183,11 +183,17 @@ export default function directComputerUse(pi: ExtensionAPI) {
       });
       const rendered = await toPiContent(result.content);
       const details: JsonObject = { calls: result.calls };
+      if (result.error) details.error = result.error;
       if (rendered.fullOutputPath) details.fullOutputPath = rendered.fullOutputPath;
       return { content: rendered.content, details };
     },
-    renderCall(_args, theme) {
-      return new Text(theme.fg("toolTitle", theme.bold("computer_use")), 0, 0);
+    renderCall(args, theme) {
+      const parsed = z.object({ code: z.string() }).safeParse(args);
+      const firstLine = parsed.success
+        ? parsed.data.code.split("\n").map((line) => line.trim()).find(Boolean)?.slice(0, 100)
+        : undefined;
+      const label = theme.fg("toolTitle", theme.bold("computer_use"));
+      return new Text(firstLine ? `${label} ${theme.fg("dim", firstLine)}` : label, 0, 0);
     },
   });
 

--- a/integrations/pi/index.ts
+++ b/integrations/pi/index.ts
@@ -49,7 +49,7 @@ Available globals:
 - emitImage(state.screenshot) returns a screenshot to Pi
 - store is a persistent JSON object shared across calls
 
-get_app_state may return an accessibility-tree diff after the first inspection. Pass disableDiff: true when you need a fresh full tree. Screenshot payloads stay outside the worker and cross it only as opaque handles.
+get_app_state may return an accessibility-tree diff after the first inspection. Pass disableDiff: true when you need a fresh full tree.
 
 Example:
 const state = await sky.get_app_state({ app: "TextEdit" });
@@ -63,47 +63,44 @@ interface PiContentResult {
 }
 
 export async function toPiContent(content: JsonObject[]): Promise<PiContentResult> {
-  const textBlocks = content
-    .filter((block) => block.type !== "image")
-    .map((block) => String(block.text ?? ""));
+  const textBlocks = content.filter((block) => block.type !== "image").map((block) => String(block.text ?? ""));
   const fullText = textBlocks.join("\n\n");
-  const aggregate = truncateHead(fullText, {
-    maxLines: DEFAULT_MAX_LINES,
-    maxBytes: DEFAULT_MAX_BYTES,
-  });
-  let fullOutputPath: string | undefined;
-  if (aggregate.truncated) {
-    const tempDir = await mkdtemp(path.join(tmpdir(), "pi-computer-use-"));
-    fullOutputPath = path.join(tempDir, "output.txt");
-    await writeFile(fullOutputPath, fullText, { encoding: "utf8", mode: 0o600 });
+  const aggregate = truncateHead(fullText, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+  if (!aggregate.truncated) {
+    return {
+      content: content.map((block) => block.type === "image"
+        ? { type: "image", data: String(block.data), mimeType: String(block.mimeType) }
+        : { type: "text", text: String(block.text ?? "") }),
+    };
   }
 
-  const result: PiContentResult = { content: [] };
-  let remainingText = aggregate.content;
-  let textIndex = 0;
-  let truncationNoticeAdded = false;
+  const tempDir = await mkdtemp(path.join(tmpdir(), "pi-computer-use-"));
+  const fullOutputPath = path.join(tempDir, "output.txt");
+  await writeFile(fullOutputPath, fullText, { encoding: "utf8", mode: 0o600 });
   const suffix = `\n\n[Official Computer Use text truncated: showing ${aggregate.outputLines} of ${aggregate.totalLines} lines (${formatSize(aggregate.outputBytes)} of ${formatSize(aggregate.totalBytes)}). Full output saved to: ${fullOutputPath}]`;
+  const result: PiContentResult = { content: [], fullOutputPath };
+  let textIndex = 0;
+  let textOffset = 0;
+  let noticeAdded = false;
   for (const block of content) {
     if (block.type === "image") {
       result.content.push({ type: "image", data: String(block.data), mimeType: String(block.mimeType) });
       continue;
     }
     const blockText = String(block.text ?? "");
-    if (!aggregate.truncated) {
-      result.content.push({ type: "text", text: blockText });
-      continue;
+    const start = textOffset + (textIndex > 0 ? 2 : 0);
+    const end = start + blockText.length;
+    const retained = aggregate.content.length > start
+      ? blockText.slice(0, Math.min(end, aggregate.content.length) - start)
+      : "";
+    const cutoffHere: boolean = !noticeAdded && aggregate.content.length < end;
+    if (retained || cutoffHere) {
+      result.content.push({ type: "text", text: `${retained}${cutoffHere ? suffix : ""}` });
+      noticeAdded ||= cutoffHere;
     }
-    if (textIndex > 0 && remainingText.startsWith("\n\n")) remainingText = remainingText.slice(2);
+    textOffset = end;
     textIndex += 1;
-    const retained = blockText.slice(0, remainingText.length);
-    remainingText = remainingText.slice(retained.length);
-    const truncatedHere = retained.length < blockText.length || (remainingText.length === 0 && textIndex < textBlocks.length);
-    if (!retained && !truncatedHere) continue;
-    const notice = truncatedHere && !truncationNoticeAdded ? suffix : "";
-    truncationNoticeAdded ||= truncatedHere;
-    result.content.push({ type: "text", text: `${retained}${notice}` });
   }
-  if (fullOutputPath) result.fullOutputPath = fullOutputPath;
   return result;
 }
 

--- a/src/code-executor.ts
+++ b/src/code-executor.ts
@@ -1,0 +1,186 @@
+import vm from "node:vm";
+import { z } from "zod";
+import type { DirectResponse, DirectServiceDependencies } from "./direct-service.ts";
+import { DirectSessionExecutor } from "./session-executor.ts";
+import {
+	COMPUTER_USE_METHODS,
+	type DirectMethod,
+	type DirectToolArguments,
+	type JsonObject,
+	type JsonValue,
+} from "./tools.ts";
+
+const MAX_CODE_BYTES = 20_000;
+const MAX_CALLS = 50;
+const SYNC_TIMEOUT_MS = 5_000;
+
+export interface ComputerUseCodeResult {
+	content: JsonObject[];
+	calls: DirectMethod[];
+}
+
+interface ImageValue extends JsonObject {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+const emittedValueSchema = z.json();
+const emittedStringSchema = z.string();
+const imageValueSchema = z.object({
+	type: z.literal("image"),
+	data: z.string(),
+	mimeType: z.string(),
+});
+
+function textFrom(response: DirectResponse): string {
+	return response.content
+		.filter((block) => block.type !== "image")
+		.map((block) => String(block.text ?? ""))
+		.join("\n");
+}
+
+function imagesFrom(response: DirectResponse): ImageValue[] {
+	return response.content
+		.filter((block) => block.type === "image")
+		.map((block) => ({
+			type: "image" as const,
+			data: String(block.data),
+			mimeType: String(block.mimeType),
+		}));
+}
+
+function listAppsFrom(text: string): JsonValue {
+	const apps: JsonObject[] = [];
+	for (const line of text.split("\n")) {
+		const match = line.match(/^(.*?) — .*? — (\S+?)(?: \[(.*)\])?$/);
+		if (!match) continue;
+		const details = match[3]?.split(", ") ?? [];
+		const app: JsonObject = { id: match[2], displayName: match[1] };
+		if (details.includes("running") || details.includes("frontmost")) app.isRunning = true;
+		const lastUsed = details.find((detail) => detail.startsWith("last-used="));
+		if (lastUsed) app.lastUsedDate = lastUsed.slice("last-used=".length);
+		const uses = details.find((detail) => detail.startsWith("uses="));
+		if (uses) app.useCount = Number(uses.slice("uses=".length));
+		apps.push(app);
+	}
+	return apps.length > 0 ? apps : text;
+}
+
+function valueFrom(method: DirectMethod, args: DirectToolArguments, response: DirectResponse): JsonValue | undefined {
+	const text = textFrom(response);
+	if (method === "list_apps") return listAppsFrom(text);
+	if (method === "get_app_state") {
+		return {
+			app: String(args.app),
+			text,
+			screenshot: imagesFrom(response)[0] ?? null,
+		};
+	}
+	if (response.structuredContent !== undefined) return response.structuredContent;
+	return text || undefined;
+}
+
+function errorFrom(response: DirectResponse): Error {
+	return new Error(textFrom(response).slice(0, 2_000) || "Official Computer Use returned an error");
+}
+
+export class ComputerUseCodeExecutor {
+	private queue = Promise.resolve();
+	private readonly sessionExecutor: DirectSessionExecutor;
+	readonly store: Record<string, JsonValue | undefined> = {};
+
+	constructor(sessionExecutor = new DirectSessionExecutor()) {
+		this.sessionExecutor = sessionExecutor;
+	}
+
+	private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.queue.then(operation);
+		this.queue = result.then(() => undefined, () => undefined);
+		return result;
+	}
+
+	execute(code: string, dependencies: DirectServiceDependencies): Promise<ComputerUseCodeResult> {
+		return this.runExclusive(async () => {
+			if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+				throw new Error(`Computer Use code exceeds ${MAX_CODE_BYTES} bytes`);
+			}
+
+			const content: JsonObject[] = [];
+			const calls: DirectMethod[] = [];
+			const methodSchema = z.enum(COMPUTER_USE_METHODS);
+			const argumentsSchema = z.record(z.string(), z.json());
+			const callBridge = async (rawMethod: string, rawArguments: string): Promise<string> => {
+				if (calls.length >= MAX_CALLS) throw new Error(`Computer Use code exceeded ${MAX_CALLS} calls`);
+				const method = methodSchema.parse(rawMethod);
+				const args = argumentsSchema.parse(JSON.parse(rawArguments));
+				calls.push(method);
+				const response = await this.sessionExecutor.execute(method, args, dependencies);
+				if (response.isError) throw errorFrom(response);
+				return JSON.stringify(valueFrom(method, args, response) ?? null);
+			};
+			const emitBridge = (rawValue: string): void => {
+				const parsed = emittedValueSchema.parse(JSON.parse(rawValue));
+				const stringResult = emittedStringSchema.safeParse(parsed);
+				content.push({
+					type: "text",
+					text: stringResult.success ? stringResult.data : JSON.stringify(parsed, null, 2),
+				});
+			};
+			const emitImageBridge = (rawValue: string): void => {
+				const parsed = imageValueSchema.parse(JSON.parse(rawValue));
+				content.push({ type: "image", data: parsed.data, mimeType: parsed.mimeType });
+			};
+			Object.setPrototypeOf(callBridge, null);
+			Object.setPrototypeOf(emitBridge, null);
+			Object.setPrototypeOf(emitImageBridge, null);
+			const context = vm.createContext({
+				__callBridge: callBridge,
+				__emitBridge: emitBridge,
+				__emitImageBridge: emitImageBridge,
+				__storeJson: JSON.stringify(this.store),
+			}, {
+				codeGeneration: { strings: false, wasm: false },
+				name: "computer-use",
+			});
+			const bootstrap = new vm.Script(`(() => {
+	const callBridge = globalThis.__callBridge;
+	const emitBridge = globalThis.__emitBridge;
+	const emitImageBridge = globalThis.__emitImageBridge;
+	const storeJson = globalThis.__storeJson;
+	delete globalThis.__callBridge;
+	delete globalThis.__emitBridge;
+	delete globalThis.__emitImageBridge;
+	delete globalThis.__storeJson;
+	const call = async (method, args = {}) => JSON.parse(await callBridge(method, JSON.stringify(args)));
+	globalThis.sky = Object.freeze({
+		list_apps: (args) => call("list_apps", args),
+		get_app_state: (args) => call("get_app_state", args),
+		click: (args) => call("click", args),
+		perform_secondary_action: (args) => call("perform_secondary_action", args),
+		set_value: (args) => call("set_value", args),
+		select_text: (args) => call("select_text", args),
+		scroll: (args) => call("scroll", args),
+		drag: (args) => call("drag", args),
+		press_key: (args) => call("press_key", args),
+		type_text: (args) => call("type_text", args),
+	});
+	globalThis.emit = (value) => emitBridge(JSON.stringify(value));
+	globalThis.emitImage = (value) => emitImageBridge(JSON.stringify(value));
+	globalThis.store = JSON.parse(storeJson);
+})()`);
+			bootstrap.runInContext(context, { timeout: SYNC_TIMEOUT_MS });
+			const script = new vm.Script(`(async () => {\n${code}\n})()`, { filename: "computer-use.js" });
+			await script.runInContext(context, { timeout: SYNC_TIMEOUT_MS });
+			const rawStore = new vm.Script("JSON.stringify(store)").runInContext(context, { timeout: SYNC_TIMEOUT_MS });
+			const nextStore = argumentsSchema.parse(JSON.parse(String(rawStore)));
+			for (const key of Object.keys(this.store)) delete this.store[key];
+			Object.assign(this.store, nextStore);
+			return { content, calls };
+		});
+	}
+
+	async close(): Promise<void> {
+		await this.runExclusive(() => this.sessionExecutor.close());
+	}
+}

--- a/src/code-executor.ts
+++ b/src/code-executor.ts
@@ -1,11 +1,10 @@
 import { Worker } from "node:worker_threads";
 import { z } from "zod";
-import type { DirectResponse, DirectServiceDependencies } from "./direct-service.ts";
+import type { DirectServiceDependencies } from "./direct-service.ts";
 import { DirectSessionExecutor } from "./session-executor.ts";
 import {
 	COMPUTER_USE_METHODS,
 	type DirectMethod,
-	type DirectToolArguments,
 	type JsonObject,
 	type JsonValue,
 } from "./tools.ts";
@@ -41,71 +40,22 @@ type WorkerMessageInput = z.input<typeof workerMessageSchema>;
 const argumentsSchema = z.record(z.string(), z.json());
 const emittedValueSchema = z.json();
 const emittedStringSchema = z.string();
-const imageValueSchema = z.object({
-	type: z.literal("image"),
-	data: z.string(),
-	mimeType: z.string(),
-});
 const screenshotHandleSchema = z.object({
 	type: z.literal("computer_use_screenshot"),
 	id: z.string(),
 });
 
-function textFrom(response: DirectResponse): string {
-	return response.content
-		.filter((block) => block.type !== "image")
-		.map((block) => String(block.text ?? ""))
-		.join("\n");
-}
-
-function imagesFrom(response: DirectResponse): ImageValue[] {
-	return response.content
-		.filter((block) => block.type === "image")
-		.map((block) => ({
-			type: "image" as const,
-			data: String(block.data),
-			mimeType: String(block.mimeType),
-		}));
-}
-
-function valueFrom(
-	method: DirectMethod,
-	args: DirectToolArguments,
-	response: DirectResponse,
-	registerScreenshot: (image: ImageValue) => JsonObject,
-): JsonValue | undefined {
-	const text = textFrom(response);
-	if (method === "get_app_state") {
-		const screenshot = imagesFrom(response)[0];
-		return {
-			app: String(args.app),
-			text,
-			screenshot: screenshot ? registerScreenshot(screenshot) : null,
-		};
-	}
-	if (response.structuredContent !== undefined) return response.structuredContent;
-	return text || undefined;
-}
-
-function errorFrom(response: DirectResponse): Error {
-	return new Error(textFrom(response).slice(0, 2_000) || "Official Computer Use returned an error");
-}
-
-function workerUrl(): URL {
-	return import.meta.url.endsWith(".ts")
-		? new URL("../dist/code-worker.js", import.meta.url)
-		: new URL("./code-worker.js", import.meta.url);
-}
+type CodeSessionExecutor = Pick<DirectSessionExecutor, "execute" | "close">;
 
 export class ComputerUseCodeExecutor {
 	private queue = Promise.resolve();
-	private readonly sessionExecutor: DirectSessionExecutor;
+	private readonly sessionExecutor: CodeSessionExecutor;
 	private readonly codeSliceTimeoutMs: number;
 	private readonly screenshots = new Map<string, ImageValue>();
 	private nextScreenshotId = 1;
 	readonly store: Record<string, JsonValue | undefined> = {};
 
-	constructor(sessionExecutor = new DirectSessionExecutor(), codeSliceTimeoutMs = CODE_SLICE_TIMEOUT_MS) {
+	constructor(sessionExecutor: CodeSessionExecutor = new DirectSessionExecutor(), codeSliceTimeoutMs = CODE_SLICE_TIMEOUT_MS) {
 		this.sessionExecutor = sessionExecutor;
 		this.codeSliceTimeoutMs = codeSliceTimeoutMs;
 	}
@@ -119,10 +69,8 @@ export class ComputerUseCodeExecutor {
 	private registerScreenshot(image: ImageValue): JsonObject {
 		const id = String(this.nextScreenshotId++);
 		this.screenshots.set(id, image);
-		while (this.screenshots.size > MAX_SCREENSHOT_HANDLES) {
-			const oldest = this.screenshots.keys().next().value;
-			if (oldest === undefined) break;
-			this.screenshots.delete(oldest);
+		if (this.screenshots.size > MAX_SCREENSHOT_HANDLES) {
+			this.screenshots.delete(this.screenshots.keys().next().value!);
 		}
 		return { type: "computer_use_screenshot", id };
 	}
@@ -135,11 +83,14 @@ export class ComputerUseCodeExecutor {
 			return new Promise<ComputerUseCodeResult>((resolve, reject) => {
 				const content: JsonObject[] = [];
 				const calls: DirectMethod[] = [];
-				const worker = new Worker(workerUrl(), { workerData: { code, store: this.store } });
+				const worker = new Worker(
+					import.meta.url.endsWith(".ts")
+						? new URL("../dist/code-worker.js", import.meta.url)
+						: new URL("./code-worker.js", import.meta.url),
+					{ workerData: { code, store: this.store } },
+				);
 				let emittedImages = 0;
 				let emittedImageBytes = 0;
-				let pendingCalls = 0;
-				let ready = false;
 				let settled = false;
 				let timer: NodeJS.Timeout | undefined;
 				const clearTimer = (): void => {
@@ -168,7 +119,7 @@ export class ComputerUseCodeExecutor {
 				};
 				const armTimer = (): void => {
 					clearTimer();
-					if (settled || !ready || pendingCalls > 0) return;
+					if (settled) return;
 					timer = setTimeout(() => stopWithError(`execution exceeded ${this.codeSliceTimeoutMs}ms between Computer Use calls`), this.codeSliceTimeoutMs);
 					timer.unref();
 				};
@@ -178,11 +129,12 @@ export class ComputerUseCodeExecutor {
 					return;
 				}
 				dependencies.signal?.addEventListener("abort", abort, { once: true });
+				let messageQueue = Promise.resolve();
 				worker.on("message", (rawMessage: WorkerMessageInput) => {
-					void (async () => {
+					messageQueue = messageQueue.then(async () => {
+						if (settled) return;
 						const message = workerMessageSchema.parse(rawMessage);
 						if (message.type === "ready") {
-							ready = true;
 							armTimer();
 							return;
 						}
@@ -193,8 +145,8 @@ export class ComputerUseCodeExecutor {
 							return;
 						}
 						if (message.type === "emit_image") {
-							const parsed = z.union([imageValueSchema, screenshotHandleSchema]).parse(JSON.parse(message.value));
-							const image = parsed.type === "image" ? parsed : this.screenshots.get(parsed.id);
+							const handle = screenshotHandleSchema.parse(JSON.parse(message.value));
+							const image = this.screenshots.get(handle.id);
 							if (!image) {
 								stopWithError("screenshot is no longer available");
 								return;
@@ -223,17 +175,32 @@ export class ComputerUseCodeExecutor {
 							return;
 						}
 						clearTimer();
-						pendingCalls += 1;
 						calls.push(message.method);
 						try {
 							const args = argumentsSchema.parse(JSON.parse(message.args));
 							const response = await this.sessionExecutor.execute(message.method, args, dependencies);
-							if (response.isError) throw errorFrom(response);
-							worker.postMessage({
-								type: "call_result",
-								id: message.id,
-								value: JSON.stringify(valueFrom(message.method, args, response, (image) => this.registerScreenshot(image)) ?? null),
-							});
+							const text = response.content
+								.filter((block) => block.type !== "image")
+								.map((block) => String(block.text ?? ""))
+								.join("\n");
+							if (response.isError) throw new Error(text.slice(0, 2_000) || "Official Computer Use returned an error");
+							let value = response.structuredContent;
+							if (message.method === "get_app_state") {
+								const block = response.content.find((item) => item.type === "image");
+								const screenshot: ImageValue | undefined = block ? {
+									type: "image",
+									data: String(block.data),
+									mimeType: String(block.mimeType),
+								} : undefined;
+								value = {
+									app: String(args.app),
+									text,
+									screenshot: screenshot ? this.registerScreenshot(screenshot) : null,
+								};
+							} else if (value === undefined) {
+								value = text || undefined;
+							}
+							worker.postMessage({ type: "call_result", id: message.id, value: JSON.stringify(value ?? null) });
 						} catch (error) {
 							worker.postMessage({
 								type: "call_result",
@@ -241,10 +208,9 @@ export class ComputerUseCodeExecutor {
 								error: error instanceof Error ? error.message : String(error),
 							});
 						} finally {
-							pendingCalls -= 1;
 							armTimer();
 						}
-					})().catch((error) => fail(error instanceof Error ? error : new Error(String(error))));
+					}).catch((error) => fail(error instanceof Error ? error : new Error(String(error))));
 				});
 				worker.once("error", (error) => fail(error));
 				worker.once("exit", (code) => {

--- a/src/code-executor.ts
+++ b/src/code-executor.ts
@@ -1,4 +1,4 @@
-import vm from "node:vm";
+import { Worker } from "node:worker_threads";
 import { z } from "zod";
 import type { DirectResponse, DirectServiceDependencies } from "./direct-service.ts";
 import { DirectSessionExecutor } from "./session-executor.ts";
@@ -12,11 +12,12 @@ import {
 
 const MAX_CODE_BYTES = 20_000;
 const MAX_CALLS = 50;
-const SYNC_TIMEOUT_MS = 5_000;
+const CODE_SLICE_TIMEOUT_MS = 5_000;
 
 export interface ComputerUseCodeResult {
 	content: JsonObject[];
 	calls: DirectMethod[];
+	error?: string;
 }
 
 interface ImageValue extends JsonObject {
@@ -25,6 +26,14 @@ interface ImageValue extends JsonObject {
 	mimeType: string;
 }
 
+const workerMessageSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("call"), id: z.number().int(), method: z.enum(COMPUTER_USE_METHODS), args: z.string() }),
+	z.object({ type: z.literal("emit"), value: z.string() }),
+	z.object({ type: z.literal("emit_image"), value: z.string() }),
+	z.object({ type: z.literal("done"), store: z.string(), error: z.string().optional() }),
+]);
+type WorkerMessageInput = z.input<typeof workerMessageSchema>;
+const argumentsSchema = z.record(z.string(), z.json());
 const emittedValueSchema = z.json();
 const emittedStringSchema = z.string();
 const imageValueSchema = z.object({
@@ -50,26 +59,8 @@ function imagesFrom(response: DirectResponse): ImageValue[] {
 		}));
 }
 
-function listAppsFrom(text: string): JsonValue {
-	const apps: JsonObject[] = [];
-	for (const line of text.split("\n")) {
-		const match = line.match(/^(.*?) — .*? — (\S+?)(?: \[(.*)\])?$/);
-		if (!match) continue;
-		const details = match[3]?.split(", ") ?? [];
-		const app: JsonObject = { id: match[2], displayName: match[1] };
-		if (details.includes("running") || details.includes("frontmost")) app.isRunning = true;
-		const lastUsed = details.find((detail) => detail.startsWith("last-used="));
-		if (lastUsed) app.lastUsedDate = lastUsed.slice("last-used=".length);
-		const uses = details.find((detail) => detail.startsWith("uses="));
-		if (uses) app.useCount = Number(uses.slice("uses=".length));
-		apps.push(app);
-	}
-	return apps.length > 0 ? apps : text;
-}
-
 function valueFrom(method: DirectMethod, args: DirectToolArguments, response: DirectResponse): JsonValue | undefined {
 	const text = textFrom(response);
-	if (method === "list_apps") return listAppsFrom(text);
 	if (method === "get_app_state") {
 		return {
 			app: String(args.app),
@@ -85,13 +76,21 @@ function errorFrom(response: DirectResponse): Error {
 	return new Error(textFrom(response).slice(0, 2_000) || "Official Computer Use returned an error");
 }
 
+function workerUrl(): URL {
+	return import.meta.url.endsWith(".ts")
+		? new URL("../dist/code-worker.js", import.meta.url)
+		: new URL("./code-worker.js", import.meta.url);
+}
+
 export class ComputerUseCodeExecutor {
 	private queue = Promise.resolve();
 	private readonly sessionExecutor: DirectSessionExecutor;
+	private readonly codeSliceTimeoutMs: number;
 	readonly store: Record<string, JsonValue | undefined> = {};
 
-	constructor(sessionExecutor = new DirectSessionExecutor()) {
+	constructor(sessionExecutor = new DirectSessionExecutor(), codeSliceTimeoutMs = CODE_SLICE_TIMEOUT_MS) {
 		this.sessionExecutor = sessionExecutor;
+		this.codeSliceTimeoutMs = codeSliceTimeoutMs;
 	}
 
 	private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
@@ -105,78 +104,106 @@ export class ComputerUseCodeExecutor {
 			if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
 				throw new Error(`Computer Use code exceeds ${MAX_CODE_BYTES} bytes`);
 			}
+			return new Promise<ComputerUseCodeResult>((resolve, reject) => {
+				const content: JsonObject[] = [];
+				const calls: DirectMethod[] = [];
+				const worker = new Worker(workerUrl(), { workerData: { code, store: this.store } });
+				let pendingCalls = 0;
+				let settled = false;
+				let timer: NodeJS.Timeout | undefined;
+				const clearTimer = (): void => {
+					if (timer) clearTimeout(timer);
+					timer = undefined;
+				};
+				const finish = (result: ComputerUseCodeResult): void => {
+					if (settled) return;
+					settled = true;
+					clearTimer();
+					dependencies.signal?.removeEventListener("abort", abort);
+					void worker.terminate();
+					resolve(result);
+				};
+				const fail = (error: Error): void => {
+					if (settled) return;
+					settled = true;
+					clearTimer();
+					dependencies.signal?.removeEventListener("abort", abort);
+					void worker.terminate();
+					reject(error);
+				};
+				const stopWithError = (message: string): void => {
+					content.push({ type: "text", text: `Computer Use code stopped: ${message}` });
+					finish({ content, calls, error: message });
+				};
+				const armTimer = (): void => {
+					clearTimer();
+					if (settled || pendingCalls > 0) return;
+					timer = setTimeout(() => stopWithError(`execution exceeded ${this.codeSliceTimeoutMs}ms between Computer Use calls`), this.codeSliceTimeoutMs);
+					timer.unref();
+				};
+				const abort = (): void => fail(new Error("Computer Use code cancelled"));
+				if (dependencies.signal?.aborted) {
+					abort();
+					return;
+				}
+				dependencies.signal?.addEventListener("abort", abort, { once: true });
+				worker.on("message", (rawMessage: WorkerMessageInput) => {
+					void (async () => {
+						const message = workerMessageSchema.parse(rawMessage);
+						if (message.type === "emit") {
+							const parsed = emittedValueSchema.parse(JSON.parse(message.value));
+							const stringResult = emittedStringSchema.safeParse(parsed);
+							content.push({ type: "text", text: stringResult.success ? stringResult.data : JSON.stringify(parsed, null, 2) });
+							return;
+						}
+						if (message.type === "emit_image") {
+							const parsed = imageValueSchema.parse(JSON.parse(message.value));
+							content.push({ type: "image", data: parsed.data, mimeType: parsed.mimeType });
+							return;
+						}
+						if (message.type === "done") {
+							const nextStore = argumentsSchema.parse(JSON.parse(message.store));
+							for (const key of Object.keys(this.store)) delete this.store[key];
+							Object.assign(this.store, nextStore);
+							if (message.error) stopWithError(message.error);
+							else finish({ content, calls });
+							return;
+						}
 
-			const content: JsonObject[] = [];
-			const calls: DirectMethod[] = [];
-			const methodSchema = z.enum(COMPUTER_USE_METHODS);
-			const argumentsSchema = z.record(z.string(), z.json());
-			const callBridge = async (rawMethod: string, rawArguments: string): Promise<string> => {
-				if (calls.length >= MAX_CALLS) throw new Error(`Computer Use code exceeded ${MAX_CALLS} calls`);
-				const method = methodSchema.parse(rawMethod);
-				const args = argumentsSchema.parse(JSON.parse(rawArguments));
-				calls.push(method);
-				const response = await this.sessionExecutor.execute(method, args, dependencies);
-				if (response.isError) throw errorFrom(response);
-				return JSON.stringify(valueFrom(method, args, response) ?? null);
-			};
-			const emitBridge = (rawValue: string): void => {
-				const parsed = emittedValueSchema.parse(JSON.parse(rawValue));
-				const stringResult = emittedStringSchema.safeParse(parsed);
-				content.push({
-					type: "text",
-					text: stringResult.success ? stringResult.data : JSON.stringify(parsed, null, 2),
+						if (calls.length >= MAX_CALLS) {
+							worker.postMessage({ type: "call_result", id: message.id, error: `Computer Use code exceeded ${MAX_CALLS} calls` });
+							return;
+						}
+						clearTimer();
+						pendingCalls += 1;
+						calls.push(message.method);
+						try {
+							const args = argumentsSchema.parse(JSON.parse(message.args));
+							const response = await this.sessionExecutor.execute(message.method, args, dependencies);
+							if (response.isError) throw errorFrom(response);
+							worker.postMessage({
+								type: "call_result",
+								id: message.id,
+								value: JSON.stringify(valueFrom(message.method, args, response) ?? null),
+							});
+						} catch (error) {
+							worker.postMessage({
+								type: "call_result",
+								id: message.id,
+								error: error instanceof Error ? error.message : String(error),
+							});
+						} finally {
+							pendingCalls -= 1;
+							armTimer();
+						}
+					})().catch((error) => fail(error instanceof Error ? error : new Error(String(error))));
 				});
-			};
-			const emitImageBridge = (rawValue: string): void => {
-				const parsed = imageValueSchema.parse(JSON.parse(rawValue));
-				content.push({ type: "image", data: parsed.data, mimeType: parsed.mimeType });
-			};
-			Object.setPrototypeOf(callBridge, null);
-			Object.setPrototypeOf(emitBridge, null);
-			Object.setPrototypeOf(emitImageBridge, null);
-			const context = vm.createContext({
-				__callBridge: callBridge,
-				__emitBridge: emitBridge,
-				__emitImageBridge: emitImageBridge,
-				__storeJson: JSON.stringify(this.store),
-			}, {
-				codeGeneration: { strings: false, wasm: false },
-				name: "computer-use",
+				worker.once("error", (error) => fail(error));
+				worker.once("exit", (code) => {
+					if (!settled) fail(new Error(`Computer Use code worker exited before completion (${code})`));
+				});
+				armTimer();
 			});
-			const bootstrap = new vm.Script(`(() => {
-	const callBridge = globalThis.__callBridge;
-	const emitBridge = globalThis.__emitBridge;
-	const emitImageBridge = globalThis.__emitImageBridge;
-	const storeJson = globalThis.__storeJson;
-	delete globalThis.__callBridge;
-	delete globalThis.__emitBridge;
-	delete globalThis.__emitImageBridge;
-	delete globalThis.__storeJson;
-	const call = async (method, args = {}) => JSON.parse(await callBridge(method, JSON.stringify(args)));
-	globalThis.sky = Object.freeze({
-		list_apps: (args) => call("list_apps", args),
-		get_app_state: (args) => call("get_app_state", args),
-		click: (args) => call("click", args),
-		perform_secondary_action: (args) => call("perform_secondary_action", args),
-		set_value: (args) => call("set_value", args),
-		select_text: (args) => call("select_text", args),
-		scroll: (args) => call("scroll", args),
-		drag: (args) => call("drag", args),
-		press_key: (args) => call("press_key", args),
-		type_text: (args) => call("type_text", args),
-	});
-	globalThis.emit = (value) => emitBridge(JSON.stringify(value));
-	globalThis.emitImage = (value) => emitImageBridge(JSON.stringify(value));
-	globalThis.store = JSON.parse(storeJson);
-})()`);
-			bootstrap.runInContext(context, { timeout: SYNC_TIMEOUT_MS });
-			const script = new vm.Script(`(async () => {\n${code}\n})()`, { filename: "computer-use.js" });
-			await script.runInContext(context, { timeout: SYNC_TIMEOUT_MS });
-			const rawStore = new vm.Script("JSON.stringify(store)").runInContext(context, { timeout: SYNC_TIMEOUT_MS });
-			const nextStore = argumentsSchema.parse(JSON.parse(String(rawStore)));
-			for (const key of Object.keys(this.store)) delete this.store[key];
-			Object.assign(this.store, nextStore);
-			return { content, calls };
 		});
 	}
 

--- a/src/code-executor.ts
+++ b/src/code-executor.ts
@@ -12,7 +12,11 @@ import {
 
 const MAX_CODE_BYTES = 20_000;
 const MAX_CALLS = 50;
+const MAX_SCREENSHOT_HANDLES = 50;
+const MAX_EMITTED_IMAGES = 10;
+const MAX_EMITTED_IMAGE_BYTES = 20 * 1024 * 1024;
 const CODE_SLICE_TIMEOUT_MS = 5_000;
+const WORKER_STARTUP_TIMEOUT_MS = 5_000;
 
 export interface ComputerUseCodeResult {
 	content: JsonObject[];
@@ -27,6 +31,7 @@ interface ImageValue extends JsonObject {
 }
 
 const workerMessageSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("ready") }),
 	z.object({ type: z.literal("call"), id: z.number().int(), method: z.enum(COMPUTER_USE_METHODS), args: z.string() }),
 	z.object({ type: z.literal("emit"), value: z.string() }),
 	z.object({ type: z.literal("emit_image"), value: z.string() }),
@@ -40,6 +45,10 @@ const imageValueSchema = z.object({
 	type: z.literal("image"),
 	data: z.string(),
 	mimeType: z.string(),
+});
+const screenshotHandleSchema = z.object({
+	type: z.literal("computer_use_screenshot"),
+	id: z.string(),
 });
 
 function textFrom(response: DirectResponse): string {
@@ -59,13 +68,19 @@ function imagesFrom(response: DirectResponse): ImageValue[] {
 		}));
 }
 
-function valueFrom(method: DirectMethod, args: DirectToolArguments, response: DirectResponse): JsonValue | undefined {
+function valueFrom(
+	method: DirectMethod,
+	args: DirectToolArguments,
+	response: DirectResponse,
+	registerScreenshot: (image: ImageValue) => JsonObject,
+): JsonValue | undefined {
 	const text = textFrom(response);
 	if (method === "get_app_state") {
+		const screenshot = imagesFrom(response)[0];
 		return {
 			app: String(args.app),
 			text,
-			screenshot: imagesFrom(response)[0] ?? null,
+			screenshot: screenshot ? registerScreenshot(screenshot) : null,
 		};
 	}
 	if (response.structuredContent !== undefined) return response.structuredContent;
@@ -86,6 +101,8 @@ export class ComputerUseCodeExecutor {
 	private queue = Promise.resolve();
 	private readonly sessionExecutor: DirectSessionExecutor;
 	private readonly codeSliceTimeoutMs: number;
+	private readonly screenshots = new Map<string, ImageValue>();
+	private nextScreenshotId = 1;
 	readonly store: Record<string, JsonValue | undefined> = {};
 
 	constructor(sessionExecutor = new DirectSessionExecutor(), codeSliceTimeoutMs = CODE_SLICE_TIMEOUT_MS) {
@@ -99,6 +116,17 @@ export class ComputerUseCodeExecutor {
 		return result;
 	}
 
+	private registerScreenshot(image: ImageValue): JsonObject {
+		const id = String(this.nextScreenshotId++);
+		this.screenshots.set(id, image);
+		while (this.screenshots.size > MAX_SCREENSHOT_HANDLES) {
+			const oldest = this.screenshots.keys().next().value;
+			if (oldest === undefined) break;
+			this.screenshots.delete(oldest);
+		}
+		return { type: "computer_use_screenshot", id };
+	}
+
 	execute(code: string, dependencies: DirectServiceDependencies): Promise<ComputerUseCodeResult> {
 		return this.runExclusive(async () => {
 			if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
@@ -108,7 +136,10 @@ export class ComputerUseCodeExecutor {
 				const content: JsonObject[] = [];
 				const calls: DirectMethod[] = [];
 				const worker = new Worker(workerUrl(), { workerData: { code, store: this.store } });
+				let emittedImages = 0;
+				let emittedImageBytes = 0;
 				let pendingCalls = 0;
+				let ready = false;
 				let settled = false;
 				let timer: NodeJS.Timeout | undefined;
 				const clearTimer = (): void => {
@@ -137,7 +168,7 @@ export class ComputerUseCodeExecutor {
 				};
 				const armTimer = (): void => {
 					clearTimer();
-					if (settled || pendingCalls > 0) return;
+					if (settled || !ready || pendingCalls > 0) return;
 					timer = setTimeout(() => stopWithError(`execution exceeded ${this.codeSliceTimeoutMs}ms between Computer Use calls`), this.codeSliceTimeoutMs);
 					timer.unref();
 				};
@@ -150,6 +181,11 @@ export class ComputerUseCodeExecutor {
 				worker.on("message", (rawMessage: WorkerMessageInput) => {
 					void (async () => {
 						const message = workerMessageSchema.parse(rawMessage);
+						if (message.type === "ready") {
+							ready = true;
+							armTimer();
+							return;
+						}
 						if (message.type === "emit") {
 							const parsed = emittedValueSchema.parse(JSON.parse(message.value));
 							const stringResult = emittedStringSchema.safeParse(parsed);
@@ -157,8 +193,20 @@ export class ComputerUseCodeExecutor {
 							return;
 						}
 						if (message.type === "emit_image") {
-							const parsed = imageValueSchema.parse(JSON.parse(message.value));
-							content.push({ type: "image", data: parsed.data, mimeType: parsed.mimeType });
+							const parsed = z.union([imageValueSchema, screenshotHandleSchema]).parse(JSON.parse(message.value));
+							const image = parsed.type === "image" ? parsed : this.screenshots.get(parsed.id);
+							if (!image) {
+								stopWithError("screenshot is no longer available");
+								return;
+							}
+							const imageBytes = Buffer.byteLength(image.data, "utf8");
+							if (emittedImages >= MAX_EMITTED_IMAGES || emittedImageBytes + imageBytes > MAX_EMITTED_IMAGE_BYTES) {
+								stopWithError(`emitted images exceed ${MAX_EMITTED_IMAGES} images or ${MAX_EMITTED_IMAGE_BYTES} bytes`);
+								return;
+							}
+							emittedImages += 1;
+							emittedImageBytes += imageBytes;
+							content.push(image);
 							return;
 						}
 						if (message.type === "done") {
@@ -184,7 +232,7 @@ export class ComputerUseCodeExecutor {
 							worker.postMessage({
 								type: "call_result",
 								id: message.id,
-								value: JSON.stringify(valueFrom(message.method, args, response) ?? null),
+								value: JSON.stringify(valueFrom(message.method, args, response, (image) => this.registerScreenshot(image)) ?? null),
 							});
 						} catch (error) {
 							worker.postMessage({
@@ -202,12 +250,19 @@ export class ComputerUseCodeExecutor {
 				worker.once("exit", (code) => {
 					if (!settled) fail(new Error(`Computer Use code worker exited before completion (${code})`));
 				});
-				armTimer();
+				timer = setTimeout(() => fail(new Error("Computer Use code worker failed to start")), WORKER_STARTUP_TIMEOUT_MS);
+				timer.unref();
 			});
 		});
 	}
 
 	async close(): Promise<void> {
-		await this.runExclusive(() => this.sessionExecutor.close());
+		await this.runExclusive(async () => {
+			try {
+				await this.sessionExecutor.close();
+			} finally {
+				this.screenshots.clear();
+			}
+		});
 	}
 }

--- a/src/code-worker.ts
+++ b/src/code-worker.ts
@@ -1,5 +1,6 @@
 import vm from "node:vm";
 import { parentPort, workerData } from "node:worker_threads";
+import { z } from "zod";
 import type { JsonObject } from "./tools.ts";
 
 interface WorkerInput {
@@ -13,6 +14,10 @@ interface CallResultMessage {
 	value?: string;
 	error?: string;
 }
+
+const MAX_BRIDGE_BYTES = 1_000_000;
+const MAX_EMITS = 100;
+const bridgeStringSchema = z.string();
 
 // SAFETY: ComputerUseCodeExecutor is the sole worker creator and supplies this exact cloneable shape.
 const input = workerData as WorkerInput;
@@ -31,15 +36,33 @@ port.on("message", (message: CallResultMessage) => {
 	else waiter.resolve(message.value ?? "null");
 });
 
+let emitCount = 0;
+let emittedBytes = 0;
+const checkBridgeValue = (value: string, label: string): number => {
+	const bytes = Buffer.byteLength(value, "utf8");
+	if (bytes > MAX_BRIDGE_BYTES) throw new Error(`${label} exceeds ${MAX_BRIDGE_BYTES} bytes`);
+	return bytes;
+};
 const callBridge = (method: string, args: string): Promise<string> => {
+	checkBridgeValue(args, "Computer Use arguments");
 	const id = nextCallId++;
 	return new Promise((resolve, reject) => {
 		pending.set(id, { resolve, reject });
 		port.postMessage({ type: "call", id, method, args });
 	});
 };
-const emitBridge = (value: string): void => port.postMessage({ type: "emit", value });
-const emitImageBridge = (value: string): void => port.postMessage({ type: "emit_image", value });
+const emitValue = (type: "emit" | "emit_image", value: string): void => {
+	if (emitCount >= MAX_EMITS) throw new Error(`Computer Use code exceeded ${MAX_EMITS} emits`);
+	const bytes = checkBridgeValue(value, "Computer Use emitted value");
+	if (emittedBytes + bytes > MAX_BRIDGE_BYTES) {
+		throw new Error(`Computer Use emitted output exceeds ${MAX_BRIDGE_BYTES} bytes`);
+	}
+	emitCount += 1;
+	emittedBytes += bytes;
+	port.postMessage({ type, value });
+};
+const emitBridge = (value: string): void => emitValue("emit", value);
+const emitImageBridge = (value: string): void => emitValue("emit_image", value);
 Object.setPrototypeOf(callBridge, null);
 Object.setPrototypeOf(emitBridge, null);
 Object.setPrototypeOf(emitImageBridge, null);
@@ -84,16 +107,27 @@ const bootstrap = new vm.Script(`(() => {
 	globalThis.store = JSON.parse(storeJson);
 })()`);
 
+const serializedStore = (): string => {
+	const parsed = bridgeStringSchema.safeParse(new vm.Script("JSON.stringify(store)").runInContext(context));
+	if (!parsed.success) throw new Error("Computer Use store must remain a JSON object");
+	checkBridgeValue(parsed.data, "Computer Use store");
+	return parsed.data;
+};
+
 try {
 	bootstrap.runInContext(context);
+	port.postMessage({ type: "ready" });
 	const script = new vm.Script(`(async () => {\n${input.code}\n})()`, { filename: "computer-use.js" });
 	await script.runInContext(context);
-	const rawStore = new vm.Script("JSON.stringify(store)").runInContext(context);
-	port.postMessage({ type: "done", store: String(rawStore) });
+	port.postMessage({ type: "done", store: serializedStore() });
 } catch (error) {
+	let store = JSON.stringify(input.store);
+	try {
+		store = serializedStore();
+	} catch {}
 	port.postMessage({
 		type: "done",
-		store: JSON.stringify(input.store),
+		store,
 		error: error instanceof Error ? error.message : String(error),
 	});
 }

--- a/src/code-worker.ts
+++ b/src/code-worker.ts
@@ -1,0 +1,99 @@
+import vm from "node:vm";
+import { parentPort, workerData } from "node:worker_threads";
+import type { JsonObject } from "./tools.ts";
+
+interface WorkerInput {
+	code: string;
+	store: JsonObject;
+}
+
+interface CallResultMessage {
+	type: "call_result";
+	id: number;
+	value?: string;
+	error?: string;
+}
+
+// SAFETY: ComputerUseCodeExecutor is the sole worker creator and supplies this exact cloneable shape.
+const input = workerData as WorkerInput;
+const port = parentPort;
+if (!port) throw new Error("Computer Use code worker requires a parent port");
+
+let nextCallId = 1;
+const pending = new Map<number, { resolve(value: string): void; reject(error: Error): void }>();
+
+port.on("message", (message: CallResultMessage) => {
+	if (message.type !== "call_result") return;
+	const waiter = pending.get(message.id);
+	if (!waiter) return;
+	pending.delete(message.id);
+	if (message.error) waiter.reject(new Error(message.error));
+	else waiter.resolve(message.value ?? "null");
+});
+
+const callBridge = (method: string, args: string): Promise<string> => {
+	const id = nextCallId++;
+	return new Promise((resolve, reject) => {
+		pending.set(id, { resolve, reject });
+		port.postMessage({ type: "call", id, method, args });
+	});
+};
+const emitBridge = (value: string): void => port.postMessage({ type: "emit", value });
+const emitImageBridge = (value: string): void => port.postMessage({ type: "emit_image", value });
+Object.setPrototypeOf(callBridge, null);
+Object.setPrototypeOf(emitBridge, null);
+Object.setPrototypeOf(emitImageBridge, null);
+
+const context = vm.createContext({
+	__callBridge: callBridge,
+	__emitBridge: emitBridge,
+	__emitImageBridge: emitImageBridge,
+	__storeJson: JSON.stringify(input.store),
+}, {
+	codeGeneration: { strings: false, wasm: false },
+	name: "computer-use",
+});
+
+const bootstrap = new vm.Script(`(() => {
+	const callBridge = globalThis.__callBridge;
+	const emitBridge = globalThis.__emitBridge;
+	const emitImageBridge = globalThis.__emitImageBridge;
+	const storeJson = globalThis.__storeJson;
+	delete globalThis.__callBridge;
+	delete globalThis.__emitBridge;
+	delete globalThis.__emitImageBridge;
+	delete globalThis.__storeJson;
+	const call = async (method, args = {}) => JSON.parse(await callBridge(method, JSON.stringify(args)));
+	globalThis.sky = Object.freeze({
+		list_apps: (args) => call("list_apps", args),
+		get_app_state: (args) => call("get_app_state", args),
+		click: (args) => call("click", args),
+		perform_secondary_action: (args) => call("perform_secondary_action", args),
+		set_value: (args) => call("set_value", args),
+		select_text: (args) => call("select_text", args),
+		scroll: (args) => call("scroll", args),
+		drag: (args) => call("drag", args),
+		press_key: (args) => call("press_key", args),
+		type_text: (args) => call("type_text", args),
+	});
+	globalThis.emit = (value) => emitBridge(JSON.stringify(value));
+	globalThis.emitImage = (value) => {
+		if (value === null) throw new Error("get_app_state returned no screenshot");
+		emitImageBridge(JSON.stringify(value));
+	};
+	globalThis.store = JSON.parse(storeJson);
+})()`);
+
+try {
+	bootstrap.runInContext(context);
+	const script = new vm.Script(`(async () => {\n${input.code}\n})()`, { filename: "computer-use.js" });
+	await script.runInContext(context);
+	const rawStore = new vm.Script("JSON.stringify(store)").runInContext(context);
+	port.postMessage({ type: "done", store: String(rawStore) });
+} catch (error) {
+	port.postMessage({
+		type: "done",
+		store: JSON.stringify(input.store),
+		error: error instanceof Error ? error.message : String(error),
+	});
+}

--- a/src/code-worker.ts
+++ b/src/code-worker.ts
@@ -8,12 +8,9 @@ interface WorkerInput {
 	store: JsonObject;
 }
 
-interface CallResultMessage {
-	type: "call_result";
-	id: number;
-	value?: string;
-	error?: string;
-}
+type CallResultMessage =
+	| { type: "call_result"; id: number; value: string }
+	| { type: "call_result"; id: number; error: string };
 
 const MAX_BRIDGE_BYTES = 1_000_000;
 const MAX_EMITS = 100;
@@ -28,12 +25,11 @@ let nextCallId = 1;
 const pending = new Map<number, { resolve(value: string): void; reject(error: Error): void }>();
 
 port.on("message", (message: CallResultMessage) => {
-	if (message.type !== "call_result") return;
 	const waiter = pending.get(message.id);
 	if (!waiter) return;
 	pending.delete(message.id);
-	if (message.error) waiter.reject(new Error(message.error));
-	else waiter.resolve(message.value ?? "null");
+	if ("error" in message) waiter.reject(new Error(message.error));
+	else waiter.resolve(message.value);
 });
 
 let emitCount = 0;
@@ -120,14 +116,14 @@ try {
 	const script = new vm.Script(`(async () => {\n${input.code}\n})()`, { filename: "computer-use.js" });
 	await script.runInContext(context);
 	port.postMessage({ type: "done", store: serializedStore() });
-} catch (error) {
-	let store = JSON.stringify(input.store);
+} catch (cause) {
+	let error = cause instanceof Error ? cause.message : String(cause);
+	let store: string;
 	try {
 		store = serializedStore();
-	} catch {}
-	port.postMessage({
-		type: "done",
-		store,
-		error: error instanceof Error ? error.message : String(error),
-	});
+	} catch (storeError) {
+		store = JSON.stringify(input.store);
+		error = storeError instanceof Error ? storeError.message : String(storeError);
+	}
+	port.postMessage({ type: "done", store, error });
 }

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -145,23 +145,43 @@ test("Computer Use code composes calls and emits only requested state", async ()
 		},
 		async close() {},
 	};
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	const result = await executor.execute(`
 const state = await sky.get_app_state({ app: "TextEdit" });
 await sky.click({ app: "TextEdit", element_index: "7" });
 await sky.type_text({ app: "TextEdit", text: "hello" });
 emit(state.text);
-emit(state.screenshot);
 emitImage(state.screenshot);
 `, {});
 	assert.deepEqual(calls.map((call) => call.method), ["get_app_state", "click", "type_text"]);
 	assert.deepEqual(result.calls, ["get_app_state", "click", "type_text"]);
 	assert.deepEqual(result.content, [
 		{ type: "text", text: "AX tree" },
-		{ type: "text", text: `{\n  "type": "computer_use_screenshot",\n  "id": "1"\n}` },
 		{ type: "image", data: "png-data", mimeType: "image/png" },
 	]);
+});
+
+test("Computer Use code waits for unawaited calls before completing", async () => {
+	let completeCall: (() => void) | undefined;
+	const session = {
+		execute() {
+			return new Promise<{ isError: boolean; content: Array<{ type: string; text: string }> }>((resolve) => {
+				completeCall = () => resolve({ isError: false, content: [{ type: "text", text: "apps" }] });
+			});
+		},
+		async close() {},
+	};
+	const executor = new ComputerUseCodeExecutor(session);
+	const execution = executor.execute(`sky.list_apps(); emit("started");`, {});
+	while (!completeCall) await new Promise((resolve) => setImmediate(resolve));
+	let settled = false;
+	void execution.then(() => { settled = true; });
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(settled, false);
+	completeCall();
+	const result = await execution;
+	assert.deepEqual(result.calls, ["list_apps"]);
+	assert.deepEqual(result.content, [{ type: "text", text: "started" }]);
 });
 
 test("Computer Use code returns the official list_apps text unchanged", async () => {
@@ -170,8 +190,7 @@ test("Computer Use code returns the official list_apps text unchanged", async ()
 		async execute() { return { isError: false, content: [{ type: "text", text: inventory }] }; },
 		async close() {},
 	};
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	const result = await executor.execute(`emit(await sky.list_apps());`, {});
 	assert.deepEqual(result.content, [{ type: "text", text: inventory }]);
 });
@@ -181,8 +200,7 @@ test("Computer Use code terminates a busy loop after an awaited call", async () 
 		async execute() { return { isError: false, content: [{ type: "text", text: "apps" }] }; },
 		async close() {},
 	};
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any, 50);
+	const executor = new ComputerUseCodeExecutor(session, 50);
 	const result = await executor.execute(`await sky.list_apps(); while (true) {}`, {});
 	assert.match(result.error ?? "", /execution exceeded 50ms/);
 	assert.deepEqual(result.calls, ["list_apps"]);
@@ -197,8 +215,7 @@ test("aborting Computer Use code terminates a busy worker without blocking Pi", 
 		},
 		async close() {},
 	};
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	await assert.rejects(
 		executor.execute(`await sky.list_apps(); while (true) {}`, { signal: controller.signal }),
 		/Computer Use code cancelled/,
@@ -213,8 +230,7 @@ test("Computer Use code preserves emits and call history after a mid-batch failu
 		},
 		async close() {},
 	};
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	const result = await executor.execute(`
 const state = await sky.get_app_state({ app: "TextEdit" });
 store.lastState = state.text;
@@ -232,8 +248,7 @@ await sky.click({ app: "TextEdit", element_index: "missing" });
 
 test("Computer Use code bounds the number of emitted blocks", async () => {
 	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	const result = await executor.execute(`for (let i = 0; i < 101; i += 1) emit(i);`, {});
 	assert.match(result.error ?? "", /exceeded 100 emits/);
 	assert.equal(result.content.length, 101);
@@ -250,8 +265,7 @@ test("Computer Use code bounds screenshots resolved from opaque handles", async 
 		},
 		async close() {},
 	};
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	const result = await executor.execute(`
 const state = await sky.get_app_state({ app: "TextEdit" });
 for (let i = 0; i < 11; i += 1) emitImage(state.screenshot);
@@ -261,20 +275,16 @@ for (let i = 0; i < 11; i += 1) emitImage(state.screenshot);
 	assert.equal(result.content.at(-1)?.type, "text");
 });
 
-test("Computer Use code cannot escape through bridge or store constructors", async () => {
+test("Computer Use code cannot escape through bridge constructors", async () => {
 	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
-	const bridgeEscape = await executor.execute(`emit(sky.click.constructor("return process")());`, {});
-	assert.match(bridgeEscape.error ?? "", /Code generation from strings disallowed/);
-	const storeEscape = await executor.execute(`emit(store.constructor.constructor("return process")());`, {});
-	assert.match(storeEscape.error ?? "", /Code generation from strings disallowed/);
+	const executor = new ComputerUseCodeExecutor(session);
+	const result = await executor.execute(`emit(sky.click.constructor("return process")());`, {});
+	assert.match(result.error ?? "", /Code generation from strings disallowed/);
 });
 
 test("Computer Use code exposes a persistent explicit store", async () => {
 	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
-	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
-	const executor = new ComputerUseCodeExecutor(session as any);
+	const executor = new ComputerUseCodeExecutor(session);
 	await executor.execute(`store.count = 1;`, {});
 	const result = await executor.execute(`store.count += 1; emit(store);`, {});
 	assert.deepEqual(result.content, [{ type: "text", text: `{\n  "count": 2\n}` }]);
@@ -390,8 +400,9 @@ test("Pi truncates aggregate text to a private spill file without spilling image
 		assert.equal(await readFile(rendered.fullOutputPath, "utf8"), original);
 		assert.equal((await stat(rendered.fullOutputPath)).mode & 0o777, 0o600);
 		assert.deepEqual(rendered.content.map((block) => block.type), ["text", "image", "text", "image"]);
+		assert.deepEqual(rendered.content[0], { type: "text", text: first });
 		assert.deepEqual(rendered.content[1], { type: "image", data: "first-image", mimeType: "image/png" });
-		assert.match(rendered.content[2].type === "text" ? rendered.content[2].text : "", /Full output saved to:/);
+		assert.match(rendered.content[2].type === "text" ? rendered.content[2].text : "", /^\n\n\[Official Computer Use text truncated:.*Full output saved to:/s);
 		const returnedText = rendered.content.filter((block) => block.type === "text").map((block) => block.text).join("");
 		assert.ok(Buffer.byteLength(returnedText) < 55 * 1024);
 		assert.deepEqual(rendered.content[3], { type: "image", data: "second-image", mimeType: "image/png" });

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -162,45 +162,78 @@ emitImage(state.screenshot);
 	]);
 });
 
-test("Computer Use code presents list_apps as the native structured app surface", async () => {
+test("Computer Use code returns the official list_apps text unchanged", async () => {
+	const inventory = "Notes — Beta — /Applications/Notes Beta.app/ — example.NotesBeta [running]";
+	const session = {
+		async execute() { return { isError: false, content: [{ type: "text", text: inventory }] }; },
+		async close() {},
+	};
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	const result = await executor.execute(`emit(await sky.list_apps());`, {});
+	assert.deepEqual(result.content, [{ type: "text", text: inventory }]);
+});
+
+test("Computer Use code terminates a busy loop after an awaited call", async () => {
+	const session = {
+		async execute() { return { isError: false, content: [{ type: "text", text: "apps" }] }; },
+		async close() {},
+	};
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any, 50);
+	const result = await executor.execute(`await sky.list_apps(); while (true) {}`, {});
+	assert.match(result.error ?? "", /execution exceeded 50ms/);
+	assert.deepEqual(result.calls, ["list_apps"]);
+});
+
+test("aborting Computer Use code terminates a busy worker without blocking Pi", async () => {
+	const controller = new AbortController();
 	const session = {
 		async execute() {
-			return {
-				isError: false,
-				content: [{ type: "text", text: "TextEdit — /System/Applications/TextEdit.app/ — com.apple.TextEdit [running, last-used=2026-08-21, uses=251]" }],
-			};
+			setTimeout(() => controller.abort(), 20);
+			return { isError: false, content: [{ type: "text", text: "apps" }] };
 		},
 		async close() {},
 	};
 	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
 	const executor = new ComputerUseCodeExecutor(session as any);
-	const result = await executor.execute(`const apps = await sky.list_apps(); emit(apps);`, {});
-	assert.deepEqual(result.content, [{
-		type: "text",
-		text: `[
-  {
-    "id": "com.apple.TextEdit",
-    "displayName": "TextEdit",
-    "isRunning": true,
-    "lastUsedDate": "2026-08-21",
-    "useCount": 251
-  }
-]`,
-	}]);
+	await assert.rejects(
+		executor.execute(`await sky.list_apps(); while (true) {}`, { signal: controller.signal }),
+		/Computer Use code cancelled/,
+	);
+});
+
+test("Computer Use code preserves emits and call history after a mid-batch failure", async () => {
+	const session = {
+		async execute(method: DirectMethod) {
+			if (method === "click") return { isError: true, content: [{ type: "text", text: "element not found" }] };
+			return { isError: false, content: [{ type: "text", text: "initial state" }] };
+		},
+		async close() {},
+	};
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	const result = await executor.execute(`
+const state = await sky.get_app_state({ app: "TextEdit" });
+emit(state.text);
+await sky.click({ app: "TextEdit", element_index: "missing" });
+`, {});
+	assert.equal(result.error, "element not found");
+	assert.deepEqual(result.calls, ["get_app_state", "click"]);
+	assert.deepEqual(result.content, [
+		{ type: "text", text: "initial state" },
+		{ type: "text", text: "Computer Use code stopped: element not found" },
+	]);
 });
 
 test("Computer Use code cannot escape through bridge or store constructors", async () => {
 	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
 	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
 	const executor = new ComputerUseCodeExecutor(session as any);
-	await assert.rejects(
-		executor.execute(`emit(sky.click.constructor("return process")());`, {}),
-		/Code generation from strings disallowed/,
-	);
-	await assert.rejects(
-		executor.execute(`emit(store.constructor.constructor("return process")());`, {}),
-		/Code generation from strings disallowed/,
-	);
+	const bridgeEscape = await executor.execute(`emit(sky.click.constructor("return process")());`, {});
+	assert.match(bridgeEscape.error ?? "", /Code generation from strings disallowed/);
+	const storeEscape = await executor.execute(`emit(store.constructor.constructor("return process")());`, {});
+	assert.match(storeEscape.error ?? "", /Code generation from strings disallowed/);
 });
 
 test("Computer Use code exposes a persistent explicit store", async () => {

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -152,12 +152,14 @@ const state = await sky.get_app_state({ app: "TextEdit" });
 await sky.click({ app: "TextEdit", element_index: "7" });
 await sky.type_text({ app: "TextEdit", text: "hello" });
 emit(state.text);
+emit(state.screenshot);
 emitImage(state.screenshot);
 `, {});
 	assert.deepEqual(calls.map((call) => call.method), ["get_app_state", "click", "type_text"]);
 	assert.deepEqual(result.calls, ["get_app_state", "click", "type_text"]);
 	assert.deepEqual(result.content, [
 		{ type: "text", text: "AX tree" },
+		{ type: "text", text: `{\n  "type": "computer_use_screenshot",\n  "id": "1"\n}` },
 		{ type: "image", data: "png-data", mimeType: "image/png" },
 	]);
 });
@@ -215,6 +217,7 @@ test("Computer Use code preserves emits and call history after a mid-batch failu
 	const executor = new ComputerUseCodeExecutor(session as any);
 	const result = await executor.execute(`
 const state = await sky.get_app_state({ app: "TextEdit" });
+store.lastState = state.text;
 emit(state.text);
 await sky.click({ app: "TextEdit", element_index: "missing" });
 `, {});
@@ -224,6 +227,38 @@ await sky.click({ app: "TextEdit", element_index: "missing" });
 		{ type: "text", text: "initial state" },
 		{ type: "text", text: "Computer Use code stopped: element not found" },
 	]);
+	assert.equal(executor.store.lastState, "initial state");
+});
+
+test("Computer Use code bounds the number of emitted blocks", async () => {
+	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	const result = await executor.execute(`for (let i = 0; i < 101; i += 1) emit(i);`, {});
+	assert.match(result.error ?? "", /exceeded 100 emits/);
+	assert.equal(result.content.length, 101);
+	assert.deepEqual(result.content.at(-1), { type: "text", text: "Computer Use code stopped: Computer Use code exceeded 100 emits" });
+});
+
+test("Computer Use code bounds screenshots resolved from opaque handles", async () => {
+	const session = {
+		async execute() {
+			return { isError: false, content: [
+				{ type: "text", text: "state" },
+				{ type: "image", data: "png-data", mimeType: "image/png" },
+			] };
+		},
+		async close() {},
+	};
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	const result = await executor.execute(`
+const state = await sky.get_app_state({ app: "TextEdit" });
+for (let i = 0; i < 11; i += 1) emitImage(state.screenshot);
+`, {});
+	assert.match(result.error ?? "", /emitted images exceed 10 images/);
+	assert.equal(result.content.filter((block) => block.type === "image").length, 10);
+	assert.equal(result.content.at(-1)?.type, "text");
 });
 
 test("Computer Use code cannot escape through bridge or store constructors", async () => {
@@ -340,18 +375,26 @@ test("idle expiry closes a retained session", async () => {
 	}
 });
 
-test("Pi truncates text to a private spill file without spilling images", async () => {
-	const original = "x".repeat(60 * 1024);
+test("Pi truncates aggregate text to a private spill file without spilling images", async () => {
+	const first = "x".repeat(30 * 1024);
+	const second = "y".repeat(30 * 1024);
+	const original = `${first}\n\n${second}`;
 	const rendered = await toPiContent([
-		{ type: "text", text: original },
-		{ type: "image", data: "image-data", mimeType: "image/png" },
+		{ type: "text", text: first },
+		{ type: "image", data: "first-image", mimeType: "image/png" },
+		{ type: "text", text: second },
+		{ type: "image", data: "second-image", mimeType: "image/png" },
 	]);
 	assert.ok(rendered.fullOutputPath);
 	try {
 		assert.equal(await readFile(rendered.fullOutputPath, "utf8"), original);
 		assert.equal((await stat(rendered.fullOutputPath)).mode & 0o777, 0o600);
-		assert.match(rendered.content[0].type === "text" ? rendered.content[0].text : "", /Full output saved to:/);
-		assert.deepEqual(rendered.content[1], { type: "image", data: "image-data", mimeType: "image/png" });
+		assert.deepEqual(rendered.content.map((block) => block.type), ["text", "image", "text", "image"]);
+		assert.deepEqual(rendered.content[1], { type: "image", data: "first-image", mimeType: "image/png" });
+		assert.match(rendered.content[2].type === "text" ? rendered.content[2].text : "", /Full output saved to:/);
+		const returnedText = rendered.content.filter((block) => block.type === "text").map((block) => block.text).join("");
+		assert.ok(Buffer.byteLength(returnedText) < 55 * 1024);
+		assert.deepEqual(rendered.content[3], { type: "image", data: "second-image", mimeType: "image/png" });
 	} finally {
 		await rm(path.dirname(rendered.fullOutputPath), { recursive: true, force: true });
 	}

--- a/test/pi-integration.test.ts
+++ b/test/pi-integration.test.ts
@@ -4,9 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import adapter, { handleOfficialElicitation, toPiContent } from "../integrations/pi/index.ts";
+import { ComputerUseCodeExecutor } from "../src/code-executor.ts";
 import type { DirectBrokerResult } from "../src/direct-broker.ts";
 import { DirectSessionExecutor } from "../src/session-executor.ts";
-import { COMPUTER_USE_METHODS, TOOL_INPUT_SCHEMAS, TOOL_METADATA, type DirectMethod } from "../src/tools.ts";
+import { type DirectMethod, type DirectToolArguments } from "../src/tools.ts";
 
 function brokerResult(text: string): DirectBrokerResult {
 	return {
@@ -101,13 +102,13 @@ test("Pi distinguishes decline from headless cancellation", async () => {
 	assert.deepEqual(headless, { action: "cancel" });
 });
 
-test("Pi registers and activates the ten Computer Use tools", async () => {
-	const tools: Array<{ name: string; description: string; parameters: unknown }> = [];
+test("Pi registers and activates one composable Computer Use tool", async () => {
+	const tools: Array<{ name: string; description: string; parameters: any }> = [];
 	const commands: string[] = [];
 	const handlers = new Map<string, () => void>();
 	const active = new Set(["read"]);
 	const fakePi = {
-		registerTool(tool: { name: string; description: string; parameters: unknown }) { tools.push(tool); },
+		registerTool(tool: { name: string; description: string; parameters: any }) { tools.push(tool); },
 		registerCommand(name: string) { commands.push(name); },
 		on(name: string, handler: () => void) { handlers.set(name, handler); },
 		getActiveTools() { return [...active]; },
@@ -116,17 +117,99 @@ test("Pi registers and activates the ten Computer Use tools", async () => {
 	// SAFETY: this focused adapter test implements every ExtensionAPI member used during registration and session_start.
 	adapter(fakePi as any);
 	assert.deepEqual(commands, ["computer-use-status"]);
-	assert.deepEqual(tools.map((tool) => tool.name).sort(), COMPUTER_USE_METHODS.map((method) => `computer_use_${method}`).sort());
-	for (const method of COMPUTER_USE_METHODS) {
-		const tool = tools.find((item) => item.name === `computer_use_${method}`);
-		assert.equal(tool?.description, TOOL_METADATA[method].description);
-		assert.deepEqual(tool?.parameters, TOOL_INPUT_SCHEMAS[method]);
-	}
+	assert.deepEqual(tools.map((tool) => tool.name), ["computer_use"]);
+	assert.match(tools[0].description, /sky\.get_app_state/);
+	assert.match(tools[0].description, /sky\.type_text/);
+	assert.deepEqual(tools[0].parameters.required, ["code"]);
 	assert.equal(handlers.has("agent_settled"), true);
 	assert.equal(handlers.has("session_shutdown"), true);
 	handlers.get("session_start")?.();
-	assert.equal(active.has("read"), true);
-	for (const method of COMPUTER_USE_METHODS) assert.equal(active.has(`computer_use_${method}`), true);
+	assert.deepEqual([...active].sort(), ["computer_use", "read"]);
+});
+
+test("Computer Use code composes calls and emits only requested state", async () => {
+	const calls: Array<{ method: DirectMethod; args: DirectToolArguments }> = [];
+	const session = {
+		async execute(method: DirectMethod, args: DirectToolArguments) {
+			calls.push({ method, args });
+			if (method === "get_app_state") {
+				return {
+					isError: false,
+					content: [
+						{ type: "text", text: "AX tree" },
+						{ type: "image", data: "png-data", mimeType: "image/png" },
+					],
+				};
+			}
+			return { isError: false, content: [] };
+		},
+		async close() {},
+	};
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	const result = await executor.execute(`
+const state = await sky.get_app_state({ app: "TextEdit" });
+await sky.click({ app: "TextEdit", element_index: "7" });
+await sky.type_text({ app: "TextEdit", text: "hello" });
+emit(state.text);
+emitImage(state.screenshot);
+`, {});
+	assert.deepEqual(calls.map((call) => call.method), ["get_app_state", "click", "type_text"]);
+	assert.deepEqual(result.calls, ["get_app_state", "click", "type_text"]);
+	assert.deepEqual(result.content, [
+		{ type: "text", text: "AX tree" },
+		{ type: "image", data: "png-data", mimeType: "image/png" },
+	]);
+});
+
+test("Computer Use code presents list_apps as the native structured app surface", async () => {
+	const session = {
+		async execute() {
+			return {
+				isError: false,
+				content: [{ type: "text", text: "TextEdit — /System/Applications/TextEdit.app/ — com.apple.TextEdit [running, last-used=2026-08-21, uses=251]" }],
+			};
+		},
+		async close() {},
+	};
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	const result = await executor.execute(`const apps = await sky.list_apps(); emit(apps);`, {});
+	assert.deepEqual(result.content, [{
+		type: "text",
+		text: `[
+  {
+    "id": "com.apple.TextEdit",
+    "displayName": "TextEdit",
+    "isRunning": true,
+    "lastUsedDate": "2026-08-21",
+    "useCount": 251
+  }
+]`,
+	}]);
+});
+
+test("Computer Use code cannot escape through bridge or store constructors", async () => {
+	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	await assert.rejects(
+		executor.execute(`emit(sky.click.constructor("return process")());`, {}),
+		/Code generation from strings disallowed/,
+	);
+	await assert.rejects(
+		executor.execute(`emit(store.constructor.constructor("return process")());`, {}),
+		/Code generation from strings disallowed/,
+	);
+});
+
+test("Computer Use code exposes a persistent explicit store", async () => {
+	const session = { async execute() { return { isError: false, content: [] }; }, async close() {} };
+	// SAFETY: this fake implements the execute and close methods used by ComputerUseCodeExecutor.
+	const executor = new ComputerUseCodeExecutor(session as any);
+	await executor.execute(`store.count = 1;`, {});
+	const result = await executor.execute(`store.count += 1; emit(store);`, {});
+	assert.deepEqual(result.content, [{ type: "text", text: `{\n  "count": 2\n}` }]);
 });
 
 test("broker setup failures remain audited", async () => {


### PR DESCRIPTION
## Summary

- replace the ten separate Pi Computer Use tools with one composable `computer_use({ code })` tool
- expose the full official `sky` method surface plus `emit`, `emitImage`, and persistent `store`
- retain the signed zero-model-turn Computer Use session and keep the MCP surface unchanged
- return only explicitly emitted output and preserve existing truncation behaviour
- execute model-authored code in a worker with cancellable code slices, paused while official Computer Use calls run
- preserve prior emits and attempted method history when a later action or script step fails

## Review fixes

- a synchronous loop after `await` can no longer block Pi's main thread; timeout and AbortSignal both terminate the worker
- mid-batch failures return prior emitted observations, `details.calls`, and a clear terminal error block
- removed the fragile `list_apps` text parser and now return official app-server text unchanged
- clarified the Pi/MCP ten-method contract in `AGENTS.md`
- `emitImage(null)` now reports that `get_app_state` returned no screenshot
- compact rendering shows the first non-empty code line
- screenshot payloads stay in the parent process behind bounded opaque handles instead of crossing the worker twice
- emitted text, images, bridge payloads, and persistent store state are bounded

## Verification

- `npm run check`
- `npm run check:pi`
- `npm test` — 53 passing
- regression coverage for post-`await` busy loops, unawaited call ordering, AbortSignal cancellation, partial batch output, raw `list_apps` text, and bridge escapes
- live Pi acceptance: one `computer_use` invocation called `list_apps` and `get_app_state` sequentially and returned `{"inventoryHasTextEdit":true,"inspected":"TextEdit","hasTree":true}`


