### PR TITLE
Release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-computer-use-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-computer-use-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Expose the official macOS Computer Use tools directly to Pi and MCP clients without a nested model.",
   "author": "Thomas Mustier",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump package version to 0.5.0 for the composable Pi Computer Use release

## Verification

- `npm run check`
- `npm run check:pi`
- `npm test` — 53 passing
- `npm pack --dry-run`
- `npm audit --omit=dev` — 0 vulnerabilities